### PR TITLE
Enable specifying api key in config

### DIFF
--- a/packages/local/package.json
+++ b/packages/local/package.json
@@ -45,7 +45,7 @@
   "scripts": {
     "postinstall": "cd registry && npm install",
     "test": "mocha",
-    "test:ci": "npm run build && mocha --exit",
+    "test:ci": "mocha --exit",
     "lint": "eslint '**/*.{js,ts}'",
     "lint:fix": "npm run lint -- --fix",
     "prepublishOnly": "npm run build",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -59,8 +59,8 @@
   },
   "scripts": {
     "prepublishOnly": "npm run build",
-    "test": "npm run test:browser && npm run test:dev",
-    "test:dev": "mocha --exit",
+    "test": "npm run test:browser && npm run test:mocha",
+    "test:mocha": "mocha --exit",
     "test:browser": "npx playwright install --with-deps && PW_TS_ESM_ON=true playwright test",
     "test:browser-show-report": "npx playwright show-report",
     "test:ci": "npm run coverage",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -59,7 +59,8 @@
   },
   "scripts": {
     "prepublishOnly": "npm run build",
-    "test": "npm run test:browser && mocha --exit",
+    "test": "npm run test:browser && npm run test:dev",
+    "test:dev": "mocha --exit",
     "test:browser": "npx playwright install --with-deps && PW_TS_ESM_ON=true playwright test",
     "test:browser-show-report": "npx playwright show-report",
     "test:ci": "npm run coverage",

--- a/packages/sdk/src/helpers/config.ts
+++ b/packages/sdk/src/helpers/config.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import { type WaitableTransactionReceipt } from "../registry/utils.js";
 import { type ChainName, getBaseUrl } from "./chains.js";
 import { type Signer, type ExternalProvider, getSigner } from "./ethers.js";
+import { type FetchConfig } from "../validator/client/index.js";
 
 export interface ReadConfig {
   baseUrl: string;
@@ -98,4 +99,17 @@ export function jsonFileAliases(filepath: string): AliasesNameMap {
       fs.writeFileSync(filepath, JSON.stringify(nameMap));
     },
   };
+}
+
+export function prepReadConfig(config: Partial<ReadConfig>): FetchConfig {
+  const conf: FetchConfig = {};
+  if (config.apiKey) {
+    conf.init = {
+      headers: {
+        "Api-Key": config.apiKey,
+      },
+    };
+  }
+
+  return { ...config, ...conf };
 }

--- a/packages/sdk/src/helpers/config.ts
+++ b/packages/sdk/src/helpers/config.ts
@@ -1,8 +1,8 @@
 import fs from "node:fs";
 import { type WaitableTransactionReceipt } from "../registry/utils.js";
+import { type FetchConfig } from "../validator/client/index.js";
 import { type ChainName, getBaseUrl } from "./chains.js";
 import { type Signer, type ExternalProvider, getSigner } from "./ethers.js";
-import { type FetchConfig } from "../validator/client/index.js";
 
 export interface ReadConfig {
   baseUrl: string;

--- a/packages/sdk/src/helpers/config.ts
+++ b/packages/sdk/src/helpers/config.ts
@@ -6,6 +6,7 @@ import { type Signer, type ExternalProvider, getSigner } from "./ethers.js";
 export interface ReadConfig {
   baseUrl: string;
   aliases?: AliasesNameMap;
+  apiKey?: string;
 }
 
 export interface SignerConfig {

--- a/packages/sdk/src/helpers/index.ts
+++ b/packages/sdk/src/helpers/index.ts
@@ -27,6 +27,7 @@ export {
   extractChainId,
   extractSigner,
   jsonFileAliases,
+  prepReadConfig,
 } from "./config.js";
 export {
   type Signer,

--- a/packages/sdk/src/registry/utils.ts
+++ b/packages/sdk/src/registry/utils.ts
@@ -148,7 +148,7 @@ export async function extractReadonly(
 ): Promise<ReadConfig> {
   const [{ chainId }] = await validateTables({ tables, type });
   const baseUrl = await extractBaseUrl(conn, chainId);
-  return { baseUrl };
+  return { baseUrl, apiKey: conn.apiKey };
 }
 
 /**

--- a/packages/sdk/src/validator/client/index.ts
+++ b/packages/sdk/src/validator/client/index.ts
@@ -1,6 +1,7 @@
 import { Fetcher } from "./fetcher.js";
 import { ApiResponse, ApiError, FetchConfig } from "./types.js";
 import type { paths as Paths, components as Components } from "./validator.js";
+import { prepReadConfig } from "../../helpers/index.js";
 
 export { ApiResponse, Fetcher, ApiError, FetchConfig };
 export type { Paths, Components };
@@ -9,6 +10,6 @@ export function getFetcher(
   config: FetchConfig
 ): ReturnType<typeof Fetcher.for<Paths>> {
   const fetcher = Fetcher.for<Paths>();
-  fetcher.configure(config);
+  fetcher.configure(prepReadConfig(config));
   return fetcher;
 }

--- a/packages/sdk/src/validator/index.ts
+++ b/packages/sdk/src/validator/index.ts
@@ -21,7 +21,6 @@ import {
   type TransactionReceipt,
   type Params as ReceiptParams,
 } from "./receipt.js";
-import { type FetchConfig } from "./client/index.js";
 
 export { ApiError } from "./client/index.js";
 export {
@@ -66,7 +65,7 @@ export class Validator {
    * @description Returns OK if the validator considers itself healthy
    */
   async health(opts: Signal = {}): Promise<boolean> {
-    return await getHealth(prepReadConfig(this.config), opts);
+    return await getHealth(this.config, opts);
   }
 
   /**
@@ -131,17 +130,4 @@ export class Validator {
   ): Promise<TransactionReceipt> {
     return await pollTransactionReceipt(this.config, params, opts);
   }
-}
-
-function prepReadConfig(config: Partial<ReadConfig>): FetchConfig {
-  const conf: FetchConfig = {};
-  if (config.apiKey) {
-    conf.init = {
-      headers: {
-        "Api-Key": config.apiKey,
-      },
-    };
-  }
-
-  return { ...config, ...conf };
 }

--- a/packages/sdk/src/validator/index.ts
+++ b/packages/sdk/src/validator/index.ts
@@ -138,8 +138,8 @@ function prepReadConfig(config: Partial<ReadConfig>): FetchConfig {
   if (config.apiKey) {
     conf.init = {
       headers: {
-        "Api-Key": config.apiKey
-      }
+        "Api-Key": config.apiKey,
+      },
     };
   }
 

--- a/packages/sdk/src/validator/index.ts
+++ b/packages/sdk/src/validator/index.ts
@@ -21,6 +21,7 @@ import {
   type TransactionReceipt,
   type Params as ReceiptParams,
 } from "./receipt.js";
+import { type FetchConfig } from "./client/index.js";
 
 export { ApiError } from "./client/index.js";
 export {
@@ -65,7 +66,7 @@ export class Validator {
    * @description Returns OK if the validator considers itself healthy
    */
   async health(opts: Signal = {}): Promise<boolean> {
-    return await getHealth(this.config, opts);
+    return await getHealth(prepReadConfig(this.config), opts);
   }
 
   /**
@@ -130,4 +131,17 @@ export class Validator {
   ): Promise<TransactionReceipt> {
     return await pollTransactionReceipt(this.config, params, opts);
   }
+}
+
+function prepReadConfig(config: Partial<ReadConfig>): FetchConfig {
+  const conf: FetchConfig = {};
+  if (config.apiKey) {
+    conf.init = {
+      headers: {
+        "Api-Key": config.apiKey
+      }
+    };
+  }
+
+  return { ...config, ...conf };
 }

--- a/packages/sdk/src/validator/query.ts
+++ b/packages/sdk/src/validator/query.ts
@@ -1,4 +1,4 @@
-import { type Signal } from "../helpers/await.js";
+import { type Signal } from "../helpers/index.js";
 import { type FetchConfig, type Paths, getFetcher } from "./client/index.js";
 import { hoistApiError } from "./errors.js";
 

--- a/packages/sdk/test/browser/server/package-lock.json
+++ b/packages/sdk/test/browser/server/package-lock.json
@@ -4010,7 +4010,8 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-4.0.0.tgz",
       "integrity": "sha512-e0X4jErIxAB5oLtDqbHvHpJe/uWNkdpYV83AOG2xo2tEVSzCzewgJMtREZM30wXnM5ls90hxiOtAuVU6H5JgbA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@volar/language-core": {
       "version": "1.0.24",
@@ -4189,7 +4190,8 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@vue/tsconfig/-/tsconfig-0.1.3.tgz",
       "integrity": "sha512-kQVsh8yyWPvHpb8gIc9l/HIDiiVUy1amynLNpCy8p+FoCiZXCo6fQos5/097MmnNZc9AtseDsCrfkhqCrJ8Olg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "aes-js": {
       "version": "3.0.0",
@@ -5533,7 +5535,8 @@
       "version": "7.4.6",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
       "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "y18n": {
       "version": "5.0.8",

--- a/packages/sdk/test/database.test.ts
+++ b/packages/sdk/test/database.test.ts
@@ -1,11 +1,18 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
-import assert, { deepStrictEqual, strictEqual, rejects, match } from "assert";
+import assert, {
+  deepStrictEqual,
+  equal,
+  strictEqual,
+  rejects,
+  match,
+} from "assert";
 import { describe, test } from "mocha";
 import { getAccounts } from "@tableland/local";
 import { getDefaultProvider } from "ethers";
 import { Database } from "../src/database.js";
 import { Statement } from "../src/statement.js";
 import { getAbortSignal } from "../src/helpers/await.js";
+import { getDelay, getRange } from "../src/helpers/utils.js";
 import {
   TEST_TIMEOUT_FACTOR,
   TEST_PROVIDER_URL,
@@ -678,6 +685,45 @@ describe("database", function () {
         strictEqual(err.cause.message, "not implemented yet");
         return true;
       });
+    });
+  });
+
+  describe("rate limit", function () {
+    test("when too many read calls are sent", async function () {
+      await rejects(
+        Promise.all(
+          getRange(15).map(async () => {
+            return await db.prepare("select * from healthbot_31337_1;").all();
+          })
+        ),
+        (err: any) => {
+          strictEqual(err.message, "ALL_ERROR: Too Many Requests");
+          return true;
+        }
+      );
+      await getDelay(2000);
+    });
+
+    test("when valid api key is used there is no limit on read queries", async function () {
+      const apiKey = "foo";
+      const db = new Database({
+        signer,
+        autoWait: true,
+        apiKey,
+      });
+      const responses = await Promise.all(
+        getRange(15).map(async () => {
+          return await db.prepare("select * from healthbot_31337_1;").all();
+        })
+      );
+
+      equal(responses.length, 15);
+      equal(
+        responses.every((r: unknown) => r === true),
+        true
+      );
+      // need to ensure the following tests aren't affected by validator throttling
+      await getDelay(2000);
     });
   });
 });

--- a/packages/sdk/test/database.test.ts
+++ b/packages/sdk/test/database.test.ts
@@ -701,6 +701,8 @@ describe("database", function () {
           return true;
         }
       );
+
+      // need to ensure the following tests aren't affected by validator throttling
       await getDelay(2000);
     });
 
@@ -717,13 +719,14 @@ describe("database", function () {
         })
       );
 
-      equal(responses.length, 15);
-      equal(
-        responses.every((r: unknown) => r === true),
-        true
-      );
       // need to ensure the following tests aren't affected by validator throttling
       await getDelay(2000);
+
+      equal(responses.length, 15);
+      for (const i in responses) {
+        const res = responses[i];
+        deepStrictEqual(res.results, [{ counter: 1 }]);
+      }
     });
   });
 });

--- a/packages/sdk/test/database.test.ts
+++ b/packages/sdk/test/database.test.ts
@@ -723,8 +723,7 @@ describe("database", function () {
       await getDelay(2000);
 
       equal(responses.length, 15);
-      for (const i in responses) {
-        const res = responses[i];
+      for (const res of responses) {
         deepStrictEqual(res.results, [{ counter: 1 }]);
       }
     });

--- a/packages/sdk/test/validator.test.ts
+++ b/packages/sdk/test/validator.test.ts
@@ -468,5 +468,29 @@ describe("validator", function () {
         true
       );
     });
+
+    test("when valid api key is used there is no limit on calls to `version()`", async function () {
+      const apiKey = "foo";
+      const api = new Validator({
+        baseUrl,
+        apiKey,
+      });
+      const responses = await Promise.all(
+        getRange(15).map(async () => await api.version())
+      );
+
+      equal(responses.length, 15);
+      for (const i in responses) {
+        const res = responses[i];
+        deepStrictEqual(res, {
+          binaryVersion: "n/a",
+          buildDate: "n/a",
+          gitBranch: "n/a",
+          gitCommit: "n/a",
+          gitState: "n/a",
+          gitSummary: "n/a",
+        });
+      }
+    });
   });
 });

--- a/packages/sdk/test/validator.test.ts
+++ b/packages/sdk/test/validator.test.ts
@@ -480,8 +480,7 @@ describe("validator", function () {
       );
 
       equal(responses.length, 15);
-      for (const i in responses) {
-        const res = responses[i];
+      for (const res of responses) {
         deepStrictEqual(res, {
           binaryVersion: "n/a",
           buildDate: "n/a",

--- a/packages/sdk/test/validator.test.ts
+++ b/packages/sdk/test/validator.test.ts
@@ -452,12 +452,16 @@ describe("validator", function () {
       await getDelay(5000);
     });
 
-    test("when valid api key is used there is no exeption", async function () {
-      const api = new Validator({ baseUrl });
+    test("when valid api key is used there is no limit on calls to `health()`", async function () {
+      const apiKey = "foo";
+      const api = new Validator({
+        baseUrl,
+        apiKey,
+      });
       const responses = await Promise.all(getRange(15).map(async () => await api.health()));
 
       equal(responses.length, 15);
-      console.log(JSON.stringify(responses));
+      equal(responses.every((r: unknown) => r === true), true);
     });
   });
 });

--- a/packages/sdk/test/validator.test.ts
+++ b/packages/sdk/test/validator.test.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import assert, {
   strictEqual,
+  equal,
   rejects,
   match,
   notStrictEqual,
@@ -449,6 +450,14 @@ describe("validator", function () {
         }
       );
       await getDelay(5000);
+    });
+
+    test("when valid api key is used there is no exeption", async function () {
+      const api = new Validator({ baseUrl });
+      const responses = await Promise.all(getRange(15).map(async () => await api.health()));
+
+      equal(responses.length, 15);
+      console.log(JSON.stringify(responses));
     });
   });
 });

--- a/packages/sdk/test/validator.test.ts
+++ b/packages/sdk/test/validator.test.ts
@@ -458,10 +458,15 @@ describe("validator", function () {
         baseUrl,
         apiKey,
       });
-      const responses = await Promise.all(getRange(15).map(async () => await api.health()));
+      const responses = await Promise.all(
+        getRange(15).map(async () => await api.health())
+      );
 
       equal(responses.length, 15);
-      equal(responses.every((r: unknown) => r === true), true);
+      equal(
+        responses.every((r: unknown) => r === true),
+        true
+      );
     });
   });
 });

--- a/packages/sdk/test/validator/config.json
+++ b/packages/sdk/test/validator/config.json
@@ -3,7 +3,8 @@
   "HTTP": {
     "Port": "8081",
     "RateLimInterval": "1s",
-    "MaxRequestPerInterval": 10
+    "MaxRequestPerInterval": 10,
+    "APIKey": "foo"
   },
   "Gateway": {
     "ExternalURIPrefix": "http://localhost:8081",


### PR DESCRIPTION
This enables specifying an api key that bypasses the Validator's rate limiting.
You can pass an `apiKey` parameter to the `Validator` and `Database` classes, which is converted to the correct header and send with read requests.

Example use:
```
new Validator({ apiKey, ... });
new Database({ apiKey, ... });
```