### PR TITLE
fix abort controller handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2098,9 +2098,9 @@
       "link": true
     },
     "node_modules/@tableland/evm": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tableland/evm/-/evm-4.3.0.tgz",
-      "integrity": "sha512-DweAJgho9hwjSF+0My0eB8T8OQ66Pe3IC0878s6GArA6aMDr3OYRk35TW/EgOPTBlVBgqo0S1WBHW+hswG8miw==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@tableland/evm/-/evm-4.4.0.tgz",
+      "integrity": "sha512-iSVwqr2/6ohbKavY+X0u3ysmuGCyzCz5D4IacK6vdXAqv+wIc4wR1hRBFgZs01hY5MTADxdnon1V3LQmdxAVgQ==",
       "dependencies": {
         "@openzeppelin/contracts": "4.8.3"
       },
@@ -12955,7 +12955,7 @@
       "license": "MIT AND Apache-2.0",
       "dependencies": {
         "@async-generators/from-emitter": "^0.3.0",
-        "@tableland/evm": "^4.3.0",
+        "@tableland/evm": "^4.4.0",
         "@tableland/sqlparser": "^1.3.0",
         "ethers": "^5.7.2"
       },
@@ -14519,9 +14519,9 @@
       }
     },
     "@tableland/evm": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tableland/evm/-/evm-4.3.0.tgz",
-      "integrity": "sha512-DweAJgho9hwjSF+0My0eB8T8OQ66Pe3IC0878s6GArA6aMDr3OYRk35TW/EgOPTBlVBgqo0S1WBHW+hswG8miw==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@tableland/evm/-/evm-4.4.0.tgz",
+      "integrity": "sha512-iSVwqr2/6ohbKavY+X0u3ysmuGCyzCz5D4IacK6vdXAqv+wIc4wR1hRBFgZs01hY5MTADxdnon1V3LQmdxAVgQ==",
       "requires": {
         "@openzeppelin/contracts": "4.8.3"
       }
@@ -14571,7 +14571,7 @@
         "@databases/sql": "^3.2.0",
         "@ethersproject/experimental": "^5.7.0",
         "@playwright/test": "^1.30.0",
-        "@tableland/evm": "^4.3.0",
+        "@tableland/evm": "4.4.0",
         "@tableland/sqlparser": "^1.3.0",
         "d1-orm": "^0.7.1",
         "ethers": "^5.7.2",

--- a/packages/sdk/API.md
+++ b/packages/sdk/API.md
@@ -249,16 +249,16 @@ console.log(transactionHash);
 
 The `Database` may also be run in `autoWait` mode, such that each mutating call will not resolve until it has finalized on the Tableland network. This is useful when working with D1 compatible libraries, or to avoid issues with nonce-reuse etc.
 
-Additionally, all async method calls take an optional `AbortSignal` object, which may be used to cancel or otherwise abort an inflight query. Note that this will only abort queries (including wait status), not the actual mutation transaction itself.
+Additionally, all async method calls take an optional `Signal` or `PollingController` object, which may be used to abort an inflight query. Note that this will only abort queries (including wait status), not the actual mutation transaction itself.
 
 ```typescript
-const controller = new AbortController();
-const signal = controller.signal;
+import { helpers } from "@tableland/sdk";
+const controller = helpers.createPollingController(60_000, 1500); // polling timeout and interval
 
 const stmt = db.prepare("SELECT name, age FROM users WHERE age < ?1");
 
 setTimeout(() => controller.abort(), 10);
-const young = await stmt.bind(20).all({ signal });
+const young = await stmt.bind(20).all(undefined, controller);
 /*
 Error: The operation was aborted.
 */

--- a/packages/sdk/API.md
+++ b/packages/sdk/API.md
@@ -258,7 +258,7 @@ const controller = helpers.createPollingController(60_000, 1500); // polling tim
 const stmt = db.prepare("SELECT name, age FROM users WHERE age < ?1");
 
 setTimeout(() => controller.abort(), 10);
-const young = await stmt.bind(20).all(undefined, controller);
+const young = await stmt.bind(20).all({ controller });
 /*
 Error: The operation was aborted.
 */

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -91,7 +91,7 @@
   },
   "dependencies": {
     "@async-generators/from-emitter": "^0.3.0",
-    "@tableland/evm": "^4.3.0",
+    "@tableland/evm": "^4.4.0",
     "@tableland/sqlparser": "^1.3.0",
     "ethers": "^5.7.2"
   }

--- a/packages/sdk/src/database.ts
+++ b/packages/sdk/src/database.ts
@@ -45,7 +45,7 @@ export class Database<D = unknown> {
    */
   static readOnly(chainNameOrId: ChainName | number): Database {
     console.warn(
-      "`Database.readOnly()` is a depricated method, use `new Database()`"
+      "`Database.readOnly()` is a deprecated method, use `new Database()`"
     );
     const baseUrl = getBaseUrl(chainNameOrId);
     return new Database({ baseUrl });
@@ -87,7 +87,7 @@ export class Database<D = unknown> {
    * @returns An array of run results.
    */
   //    Note: if we want this package to mirror the D1 package in a way that
-  //    enables compatability with packages built to exend D1, then the return type
+  //    enables compatability with packages built to extend D1, then the return type
   //    here will potentially affect if/how those packages work.
   //    D1-ORM is a good example: https://github.com/Interactions-as-a-Service/d1-orm/
   async batch<T = D>(
@@ -124,9 +124,7 @@ export class Database<D = unknown> {
       // and return an Array of the query results.
       if (type === "read") {
         return await Promise.all(
-          statements.map(
-            async (stmt) => await stmt.all<T>(undefined, controller)
-          )
+          statements.map(async (stmt) => await stmt.all<T>({ controller }))
         );
       }
 
@@ -202,7 +200,7 @@ export class Database<D = unknown> {
       const { statements } = await normalize(statementStrings);
       const count = statements.length;
       const statement = this.prepare(statementStrings);
-      const result = await statement.run(controller);
+      const result = await statement.run({ controller });
       // Adds a count property which isn't typed
       result.meta.count = count;
       return result;
@@ -252,7 +250,7 @@ async function normalizedToRunnables(
         // check if these tables are in the normalized table names
         // if so, filter them out (i.e., they are not being mutated)
         const filteredTables = norm.tables.filter(
-          (tableName) => !tableNames.includes(tableName)
+          (tableName: string) => !tableNames.includes(tableName)
         );
         // if the filtered tables are greater than 1, then there are two
         // tables being mutated in a single statement, which is not allowed

--- a/packages/sdk/src/helpers/await.ts
+++ b/packages/sdk/src/helpers/await.ts
@@ -1,32 +1,68 @@
+/**
+ * A type that can be awaited.
+ * @property T The type to await.
+ */
 export type Awaitable<T> = T | PromiseLike<T>;
 
+/**
+ * A signal to abort a request.
+ * @property signal The {@link AbortSignal} to abort a request.
+ * @property abort A function to abort a request.
+ */
 export interface Signal {
   signal: AbortSignal;
   abort: () => void;
 }
 
+/**
+ * A polling interval to check for results.
+ * @property interval The interval period to make new requests, in milliseconds.
+ * @property cancel A function to cancel a polling interval.
+ */
 export interface Interval {
   interval: number;
   cancel: () => void;
 }
 
+/**
+ * A polling timeout to abort a request.
+ * @property timeout The timeout period in milliseconds.
+ */
 export interface Timeout {
   timeout: number;
 }
 
+/**
+ * A polling controller with a custom timeout & interval.
+ */
 export type PollingController = Signal & Interval & Timeout;
 
+/**
+ * A waitable interface to check for results.
+ * @property wait A function to check for results.
+ */
 export interface Wait<T = unknown> {
   wait: (controller?: PollingController) => Promise<T>;
 }
 
+/**
+ * Results from an an asynchronous function.
+ */
 export interface AsyncData<T> {
   done: boolean;
   data?: T;
 }
 
+/**
+ * An asynchronous function to check for results.
+ * @returns An {@link AsyncData} object with the results, wrapped in {@link Awaitable}.
+ */
 export type AsyncFunction<T> = () => Awaitable<AsyncData<T>>;
 
+/**
+ * Create a signal to abort a request.
+ * @returns A {@link Signal} to abort a request.
+ */
 export function createSignal(): Signal {
   const controller = new AbortController();
   return {
@@ -37,6 +73,12 @@ export function createSignal(): Signal {
   };
 }
 
+/**
+ * Create a polling controller with a custom timeout & interval.
+ * @param timeout The timeout period in milliseconds.
+ * @param interval The interval period to make new requests, in milliseconds.
+ * @returns A {@link PollingController} with the custom timeout & interval.
+ */
 export function createPollingController(
   timeout: number = 60_000,
   pollingInterval: number = 1500
@@ -59,6 +101,12 @@ export function createPollingController(
   };
 }
 
+/**
+ * Create an asynchronous poller to check for results for a given function.
+ * @param fn An {@link AsyncFunction} to check for results.
+ * @param controller A {@link PollingController} with the custom timeout & interval.
+ * @returns Result from the awaited function's execution or resulting error.
+ */
 export async function getAsyncPoller<T = unknown>(
   fn: AsyncFunction<T>,
   controller?: PollingController

--- a/packages/sdk/src/helpers/await.ts
+++ b/packages/sdk/src/helpers/await.ts
@@ -6,29 +6,39 @@ export type Awaitable<T> = T | PromiseLike<T>;
 
 /**
  * A signal to abort a request.
- * @property signal The {@link AbortSignal} to abort a request.
- * @property abort A function to abort a request.
  */
 export interface Signal {
+  /**
+   * The {@link AbortSignal} to abort a request.
+   */
   signal: AbortSignal;
+  /**
+   * A function to abort a request.
+   */
   abort: () => void;
 }
 
 /**
  * A polling interval to check for results.
- * @property interval The interval period to make new requests, in milliseconds.
- * @property cancel A function to cancel a polling interval.
  */
 export interface Interval {
+  /**
+   * The interval period to make new requests, in milliseconds.
+   */
   interval: number;
+  /**
+   * A function to cancel a polling interval.
+   */
   cancel: () => void;
 }
 
 /**
  * A polling timeout to abort a request.
- * @property timeout The timeout period in milliseconds.
  */
 export interface Timeout {
+  /**
+   * The timeout period in milliseconds.
+   */
   timeout: number;
 }
 
@@ -39,9 +49,13 @@ export type PollingController = Signal & Interval & Timeout;
 
 /**
  * A waitable interface to check for results.
- * @property wait A function to check for results.
  */
 export interface Wait<T = unknown> {
+  /**
+   * A function to check for results.
+   * @param controller A {@link PollingController} with the custom timeout & interval.
+   * @returns
+   */
   wait: (controller?: PollingController) => Promise<T>;
 }
 
@@ -55,7 +69,6 @@ export interface AsyncData<T> {
 
 /**
  * An asynchronous function to check for results.
- * @returns An {@link AsyncData} object with the results, wrapped in {@link Awaitable}.
  */
 export type AsyncFunction<T> = () => Awaitable<AsyncData<T>>;
 

--- a/packages/sdk/src/helpers/await.ts
+++ b/packages/sdk/src/helpers/await.ts
@@ -10,7 +10,11 @@ export interface Interval {
   cancel: () => void;
 }
 
-export type PollingController = Signal & Interval;
+export interface Timeout {
+  timeout: number;
+}
+
+export type PollingController = Signal & Interval & Timeout;
 
 export interface Wait<T = unknown> {
   wait: (controller?: PollingController) => Promise<T>;
@@ -44,12 +48,14 @@ export function createPollingController(
   return {
     signal: controller.signal,
     abort: () => {
+      clearTimeout(timeoutId);
       controller.abort();
     },
     interval: pollingInterval,
     cancel: () => {
       clearTimeout(timeoutId);
     },
+    timeout,
   };
 }
 

--- a/packages/sdk/src/helpers/chains.ts
+++ b/packages/sdk/src/helpers/chains.ts
@@ -35,6 +35,13 @@ export type ChainName = keyof TablelandNetworkConfig;
 
 /**
  * Chain information used to determine defaults for the set of supported chains.
+ * @property chainName The name of the chain as defined in {@link ChainName}.
+ * @property chainId The chain ID.
+ * @property contractAddress The registry contract address for the chain.
+ * @property baseUrl The validator base URL for the chain.
+ * @property pollingTimeout The validator polling timeout for the chain.
+ * @property pollingInterval The validator polling interval for the chain.
+ * @property [key: string] Any additional properties.
  */
 export interface ChainInfo {
   chainName: ChainName;
@@ -46,7 +53,7 @@ export interface ChainInfo {
   [key: string]: ChainInfo[keyof ChainInfo];
 }
 
-// We simply pull this automatically from @tableland/evm to avoid keeping track seperately here.
+// We simply pull this automatically from @tableland/evm to avoid keeping track separately here.
 const entries = Object.entries(proxies) as Array<[ChainName, string]>;
 const mapped = entries.map(([chainName, contractAddress]) => {
   const uri = new URL(baseURIs[chainName]);
@@ -94,7 +101,7 @@ const supportedChainsById = Object.fromEntries(
 
 /**
  * Get the default chain information for a given chain name.
- * @param chainNameOrId The requested chain name.
+ * @param chainNameOrId The requested chain name or ID.
  * @returns An object containing the default chainId, contractAddress, chainName, and baseUrl for the given chain.
  */
 export function getChainInfo(chainNameOrId: ChainName | number): ChainInfo {
@@ -111,6 +118,11 @@ export function getChainInfo(chainNameOrId: ChainName | number): ChainInfo {
   return chainInfo;
 }
 
+/**
+ * Get whether or not a chain is a testnet.
+ * @param chainNameOrId The requested chain name or ID.
+ * @returns An boolean to indicate the testnet classification of the given chain.
+ */
 export function isTestnet(chainNameOrId: ChainName | number): boolean {
   const includesTestnet =
     getChainInfo(chainNameOrId).baseUrl.includes("testnet");
@@ -124,7 +136,7 @@ export function isTestnet(chainNameOrId: ChainName | number): boolean {
 
 /**
  * Get the default contract address for a given chain name.
- * @param chainNameOrId The requested chain name.
+ * @param chainNameOrId The requested chain name or ID.
  * @returns A hex string representing the default address for the Tableland registry contract.
  */
 export function getContractAddress(chainNameOrId: ChainName | number): string {
@@ -132,9 +144,9 @@ export function getContractAddress(chainNameOrId: ChainName | number): string {
 }
 
 /**
- * Get the default chain id for a given chain name.
- * @param chainNameOrId The requested chain name.
- * @returns A number representing the default chain id of the requested chain.
+ * Get the default chain ID for a given chain name.
+ * @param chainNameOrId The requested chain name or ID.
+ * @returns A number representing the default chain ID of the requested chain.
  */
 export function getChainId(chainNameOrId: ChainName | number): number {
   return getChainInfo(chainNameOrId).chainId;
@@ -150,9 +162,9 @@ export function getBaseUrl(chainNameOrId: ChainName | number): string {
 }
 
 /**
- * Create a `PollingController` with chain-specific timeout & interval.
+ * Create a polling controller with chain-specific timeout & interval.
  * @param chainNameOrId The requested chain name.
- * @returns A `PollingController` with standard timeout & interval per-chain.
+ * @returns A {@link PollingController} with standard timeout & interval per-chain.
  */
 export function getChainPollingController(
   chainNameOrId: ChainName | number

--- a/packages/sdk/src/helpers/chains.ts
+++ b/packages/sdk/src/helpers/chains.ts
@@ -1,32 +1,10 @@
 import {
   proxies,
   baseURIs,
-  // validatorPollingTimeouts,
+  validatorPollingTimeouts,
   type TablelandNetworkConfig,
 } from "@tableland/evm/network.js";
 import { createPollingController, type PollingController } from "./await.js";
-
-// TMP: TODO remove once included in @tableland/evm
-const validatorPollingTimeouts = {
-  // mainnets
-  mainnet: 40_000,
-  homestead: 40_000,
-  optimism: 10_000,
-  arbitrum: 10_000,
-  "arbitrum-nova": 10_000,
-  matic: 15_000,
-  filecoin: 210_000,
-  // testnets
-  sepolia: 40_000,
-  "optimism-goerli": 10_000,
-  "arbitrum-goerli": 10_000,
-  maticmum: 15_000,
-  "filecoin-calibration": 210_000,
-  "optimism-goerli-staging": 10_000,
-  // local
-  localhost: 5_000,
-  "local-tableland": 5_000,
-};
 
 /**
  * The set of supported chain names as used by the Tableland network.
@@ -56,6 +34,7 @@ export interface ChainInfo {
 // We simply pull this automatically from @tableland/evm to avoid keeping track separately here.
 const entries = Object.entries(proxies) as Array<[ChainName, string]>;
 const mapped = entries.map(([chainName, contractAddress]) => {
+  // @ts-expect-error this imported object's values are always a string
   const uri = new URL(baseURIs[chainName]);
   const baseUrl = `${uri.protocol}//${uri.host}/api/v1`;
   const chainId = parseInt(

--- a/packages/sdk/src/helpers/config.ts
+++ b/packages/sdk/src/helpers/config.ts
@@ -1,4 +1,5 @@
 import { type WaitableTransactionReceipt } from "../registry/utils.js";
+import { type PollingController } from "./await.js";
 import { type FetchConfig } from "../validator/client/index.js";
 import { type ChainName, getBaseUrl } from "./chains.js";
 import { type Signer, type ExternalProvider, getSigner } from "./ethers.js";
@@ -28,10 +29,11 @@ export interface AliasesNameMap {
 
 export async function checkWait(
   config: Config & Partial<AutoWaitConfig>,
-  receipt: WaitableTransactionReceipt
+  receipt: WaitableTransactionReceipt,
+  controller?: PollingController
 ): Promise<WaitableTransactionReceipt> {
   if (config.autoWait ?? false) {
-    const waited = await receipt.wait();
+    const waited = await receipt.wait(controller);
     return { ...receipt, ...waited };
   }
   return receipt;

--- a/packages/sdk/src/helpers/config.ts
+++ b/packages/sdk/src/helpers/config.ts
@@ -1,6 +1,6 @@
 import { type WaitableTransactionReceipt } from "../registry/utils.js";
-import { type PollingController } from "./await.js";
 import { type FetchConfig } from "../validator/client/index.js";
+import { type PollingController } from "./await.js";
 import { type ChainName, getBaseUrl } from "./chains.js";
 import { type Signer, type ExternalProvider, getSigner } from "./ethers.js";
 

--- a/packages/sdk/src/helpers/index.ts
+++ b/packages/sdk/src/helpers/index.ts
@@ -1,8 +1,10 @@
 export {
   type Signal,
   type Wait,
-  type SignalAndInterval,
+  type PollingController,
   type Interval,
+  createSignal,
+  createPollingController,
 } from "./await.js";
 export {
   type ChainName,

--- a/packages/sdk/src/lowlevel.ts
+++ b/packages/sdk/src/lowlevel.ts
@@ -252,10 +252,10 @@ function catchNotFound(err: unknown): [] {
 export async function queryRaw<T = unknown>(
   config: ReadConfig,
   statement: string,
-  opts: Signal = {}
+  signal?: Signal
 ): Promise<Array<ValueOf<T>>> {
   const params = { statement, format: "table" } as const;
-  const response = await getQuery<T>(config, params, opts)
+  const response = await getQuery<T>(config, params, signal)
     .then((res) => res.rows)
     .catch(catchNotFound);
   return response;
@@ -264,19 +264,21 @@ export async function queryRaw<T = unknown>(
 export async function queryAll<T = unknown>(
   config: ReadConfig,
   statement: string,
-  opts: Signal = {}
+  signal?: Signal
 ): Promise<ObjectsFormat<T>> {
   const params = { statement, format: "objects" } as const;
-  const response = await getQuery<T>(config, params, opts).catch(catchNotFound);
+  const response = await getQuery<T>(config, params, signal).catch(
+    catchNotFound
+  );
   return response;
 }
 
 export async function queryFirst<T = unknown>(
   config: ReadConfig,
   statement: string,
-  opts: Signal = {}
+  signal?: Signal
 ): Promise<T | null> {
-  const response = await queryAll<T>(config, statement, opts).catch(
+  const response = await queryAll<T>(config, statement, signal).catch(
     catchNotFound
   );
   return response.shift() ?? null;

--- a/packages/sdk/src/registry/utils.ts
+++ b/packages/sdk/src/registry/utils.ts
@@ -4,7 +4,7 @@ import {
 } from "../validator/receipt.js";
 import { type Runnable } from "../registry/index.js";
 import { normalize } from "../helpers/index.js";
-import { type SignalAndInterval, type Wait } from "../helpers/await.js";
+import { type PollingController, type Wait } from "../helpers/await.js";
 import {
   type Config,
   type ReadConfig,
@@ -173,9 +173,9 @@ export async function wrapTransaction(
   const name = `${prefix}_${chainId}_${_params.tableIds[0]}`;
   const params = { ..._params, chainId, tableId: _params.tableIds[0] };
   const wait = async (
-    opts: SignalAndInterval = {}
+    controller?: PollingController
   ): Promise<TransactionReceipt & Named> => {
-    const receipt = await pollTransactionReceipt(conn, params, opts);
+    const receipt = await pollTransactionReceipt(conn, params, controller);
     if (receipt.error != null) {
       throw new Error(receipt.error);
     }
@@ -244,9 +244,9 @@ export async function wrapManyTransaction(
   };
 
   const wait = async (
-    opts: SignalAndInterval = {}
+    controller?: PollingController
   ): Promise<TransactionReceipt & Named> => {
-    const receipt = await pollTransactionReceipt(conn, params, opts);
+    const receipt = await pollTransactionReceipt(conn, params, controller);
     if (receipt.error != null) {
       throw new Error(receipt.error);
     }

--- a/packages/sdk/src/statement.ts
+++ b/packages/sdk/src/statement.ts
@@ -34,7 +34,7 @@ export { type ValuesType, type Parameters, type ValueOf, type BaseType };
 
 /**
  * Options for `all`, `first`, `run`, and `raw` methods.
- * @property controller An optional object used to control receipt polling behavior.
+ * @property controller An optional {@link PollingController} used to control receipt polling behavior.
  */
 export interface Options {
   controller?: PollingController;

--- a/packages/sdk/src/statement.ts
+++ b/packages/sdk/src/statement.ts
@@ -153,7 +153,7 @@ export class Statement<S = unknown> {
    * Executes a query and returns all rows and metadata.
    * @param opts An optional object used to control behavior, see {@link Options}
    */
-  async all<T = S>(opts?: Options): Promise<Result<T>> {
+  async all<T = S>(opts: Options = {}): Promise<Result<T>> {
     try {
       const start = performance.now();
       const { sql, type, tables } = await this.#parseAndExtract();
@@ -163,12 +163,12 @@ export class Statement<S = unknown> {
             type,
             tables,
           });
-          const results = await queryAll<T>(config, sql, opts?.controller);
+          const results = await queryAll<T>(config, sql, opts.controller);
           return wrapResult(results, performance.now() - start);
         }
         default: {
           return wrapResult<T>(
-            await this.#waitExec({ type, sql, tables }, opts?.controller),
+            await this.#waitExec({ type, sql, tables }, opts.controller),
             performance.now() - start
           );
         }
@@ -200,7 +200,7 @@ export class Statement<S = unknown> {
   ): Promise<T[K] | null>;
   async first<T = S, K extends keyof T = keyof T>(
     colName?: K,
-    opts?: Options
+    opts: Options = {}
   ): Promise<T | T[K] | null> {
     try {
       const { sql, type, tables } = await this.#parseAndExtract();
@@ -210,7 +210,7 @@ export class Statement<S = unknown> {
             type,
             tables,
           });
-          const results = await queryFirst<T>(config, sql, opts?.controller);
+          const results = await queryFirst<T>(config, sql, opts.controller);
           if (results == null || colName == null) {
             return results;
           }
@@ -223,7 +223,7 @@ export class Statement<S = unknown> {
               sql,
               tables,
             },
-            opts?.controller
+            opts.controller
           );
           return null;
         }
@@ -241,7 +241,7 @@ export class Statement<S = unknown> {
    * @param controller An optional object used to control behavior, see {@link Options}
    * @returns A results object with metadata only (results are null or an empty array).
    */
-  async run(opts?: Options): Promise<Result<never>> {
+  async run(opts: Options = {}): Promise<Result<never>> {
     try {
       const start = performance.now();
       const { sql, type, tables } = await this.#parseAndExtract();
@@ -251,12 +251,12 @@ export class Statement<S = unknown> {
             type,
             tables,
           });
-          const results = await queryAll<never>(config, sql, opts?.controller);
+          const results = await queryAll<never>(config, sql, opts.controller);
           return wrapResult(results, performance.now() - start);
         }
         default: {
           return wrapResult(
-            await this.#waitExec({ type, sql, tables }, opts?.controller),
+            await this.#waitExec({ type, sql, tables }, opts.controller),
             performance.now() - start
           );
         }
@@ -272,7 +272,7 @@ export class Statement<S = unknown> {
    * @param controller An optional object used to control behavior, see {@link Options}
    * @returns An array of raw query results.
    */
-  async raw<T = S>(opts?: Options): Promise<Array<ValueOf<T>>> {
+  async raw<T = S>(opts: Options = {}): Promise<Array<ValueOf<T>>> {
     try {
       const { sql, type, tables } = await this.#parseAndExtract();
       switch (type) {
@@ -281,7 +281,7 @@ export class Statement<S = unknown> {
             type,
             tables,
           });
-          return await queryRaw<T>(config, sql, opts?.controller);
+          return await queryRaw<T>(config, sql, opts.controller);
         }
         default: {
           await this.#waitExec(
@@ -290,7 +290,7 @@ export class Statement<S = unknown> {
               sql,
               tables,
             },
-            opts?.controller
+            opts.controller
           );
           return [];
         }

--- a/packages/sdk/src/validator/health.ts
+++ b/packages/sdk/src/validator/health.ts
@@ -3,9 +3,9 @@ import { type FetchConfig, getFetcher } from "./client/index.js";
 
 export async function getHealth(
   config: FetchConfig,
-  opts: Signal = {}
+  signal?: Signal
 ): Promise<boolean> {
   const health = getFetcher(config).path("/health").method("get").create();
-  const { ok } = await health({}, opts);
+  const { ok } = await health({}, signal);
   return ok;
 }

--- a/packages/sdk/src/validator/index.ts
+++ b/packages/sdk/src/validator/index.ts
@@ -1,6 +1,6 @@
 import {
   type Signal,
-  type SignalAndInterval,
+  type PollingController,
   type ReadConfig,
   type ChainName,
   getBaseUrl,
@@ -72,23 +72,23 @@ export class Validator {
    * Get health status
    * @description Returns OK if the validator considers itself healthy
    */
-  async health(opts: Signal = {}): Promise<boolean> {
-    return await getHealth(this.config, opts);
+  async health(signal?: Signal): Promise<boolean> {
+    return await getHealth(this.config, signal);
   }
 
   /**
    * Get version information
    * @description Returns version information about the validator daemon
    */
-  async version(opts: Signal = {}): Promise<Version> {
-    return await getVersion(this.config, opts);
+  async version(signal?: Signal): Promise<Version> {
+    return await getVersion(this.config, signal);
   }
 
   /**
    * Get table information
    * @description Returns information about a single table, including schema information
    */
-  async getTableById(params: TableParams, opts: Signal = {}): Promise<Table> {
+  async getTableById(params: TableParams, signal?: Signal): Promise<Table> {
     if (
       typeof params.chainId !== "number" ||
       typeof params.tableId !== "string"
@@ -104,17 +104,17 @@ export class Validator {
    */
   async queryByStatement<T = unknown>(
     params: QueryParams<"objects" | undefined>,
-    opts?: Signal
+    signal?: Signal
   ): Promise<ObjectsFormat<T>>;
   async queryByStatement<T = unknown>(
     params: QueryParams<"table">,
-    opts?: Signal
+    signal?: Signal
   ): Promise<TableFormat<T>>;
   async queryByStatement<T = unknown>(
     params: QueryParams<Format>,
-    opts: Signal = {}
+    signal?: Signal
   ): Promise<TableFormat<T> | ObjectsFormat<T>> {
-    return await getQuery<T>(this.config, params as any, opts);
+    return await getQuery<T>(this.config, params as any, signal);
   }
 
   /**
@@ -123,9 +123,9 @@ export class Validator {
    */
   async receiptByTransactionHash(
     params: ReceiptParams,
-    opts: Signal = {}
+    signal?: Signal
   ): Promise<TransactionReceipt> {
-    return await getTransactionReceipt(this.config, params, opts);
+    return await getTransactionReceipt(this.config, params, signal);
   }
 
   /**
@@ -134,8 +134,8 @@ export class Validator {
    */
   async pollForReceiptByTransactionHash(
     params: ReceiptParams,
-    opts: SignalAndInterval = {}
+    controller?: PollingController
   ): Promise<TransactionReceipt> {
-    return await pollTransactionReceipt(this.config, params, opts);
+    return await pollTransactionReceipt(this.config, params, controller);
   }
 }

--- a/packages/sdk/src/validator/query.ts
+++ b/packages/sdk/src/validator/query.ts
@@ -27,23 +27,23 @@ export type Params<T extends Format> = BaseParams & { format?: T };
 export async function getQuery<T = unknown>(
   config: FetchConfig,
   params: Params<"objects" | undefined>,
-  opts?: Signal
+  signal?: Signal
 ): Promise<ObjectsFormat<T>>;
 export async function getQuery<T = unknown>(
   config: FetchConfig,
   params: Params<"table">,
-  opts?: Signal
+  signal?: Signal
 ): Promise<TableFormat<T>>;
 export async function getQuery<T = unknown>(
   config: FetchConfig,
   params: Params<Format>,
-  opts: Signal = {}
+  signal?: Signal
 ): Promise<ObjectsFormat<T> | TableFormat<T>> {
   const queryByStatement = getFetcher(config)
     .path("/query")
     .method("get")
     .create();
-  const { data } = await queryByStatement(params, opts).catch(hoistApiError);
+  const { data } = await queryByStatement(params, signal).catch(hoistApiError);
   switch (params.format) {
     case "table":
       return data as any;

--- a/packages/sdk/src/validator/receipt.ts
+++ b/packages/sdk/src/validator/receipt.ts
@@ -9,6 +9,7 @@ import {
   type Signal,
   getAsyncPoller,
 } from "../helpers/await.js";
+import { getChainPollingController } from "../helpers/chains.js";
 import { hoistApiError } from "./errors.js";
 import {
   type Components,
@@ -83,6 +84,7 @@ export async function pollTransactionReceipt(
       throw err;
     }
   };
-  const receipt = await getAsyncPoller(fn, controller);
+  const control = controller ?? getChainPollingController(params.chainId);
+  const receipt = await getAsyncPoller(fn, control);
   return receipt;
 }

--- a/packages/sdk/src/validator/tables.ts
+++ b/packages/sdk/src/validator/tables.ts
@@ -54,13 +54,13 @@ function transformResponse(obj: Response): Table {
 export async function getTable(
   config: FetchConfig,
   params: Params,
-  opts: Signal = {}
+  signal?: Signal
 ): Promise<Table> {
   const getTableById = getFetcher(config)
     .path("/tables/{chainId}/{tableId}")
     .method("get")
     .create();
-  const { data } = await getTableById(params, opts).catch(hoistApiError);
+  const { data } = await getTableById(params, signal).catch(hoistApiError);
   const transformed = transformResponse(data);
   return transformed;
 }

--- a/packages/sdk/src/validator/version.ts
+++ b/packages/sdk/src/validator/version.ts
@@ -25,10 +25,10 @@ function transformResponse(obj: Response): Version {
 
 export async function getVersion(
   config: FetchConfig,
-  opts: Signal = {}
+  signal?: Signal
 ): Promise<Version> {
   const version = getFetcher(config).path("/version").method("get").create();
-  const { data } = await version({}, opts).catch(hoistApiError);
+  const { data } = await version({}, signal).catch(hoistApiError);
   const transformed = transformResponse(data);
   return transformed;
 }

--- a/packages/sdk/test/await.test.ts
+++ b/packages/sdk/test/await.test.ts
@@ -5,6 +5,7 @@ import {
   type PollingController,
   createPollingController,
   getAsyncPoller,
+  createSignal,
 } from "../src/helpers/await.js";
 import { getDelay } from "../src/helpers/utils.js";
 
@@ -78,5 +79,19 @@ describe("await", function () {
       });
     });
     strictEqual(controller2.signal.aborted, true);
+  });
+
+  test("createSignal should return valid signal", () => {
+    const result = createSignal();
+    strictEqual(typeof result, "object");
+    strictEqual(typeof result.signal, "object");
+    strictEqual(typeof result.abort, "function");
+  });
+
+  test("createSignal should set to aborted when called", () => {
+    const result = createSignal();
+    strictEqual(result.signal.aborted, false);
+    result.abort();
+    strictEqual(result.signal.aborted, true);
   });
 });

--- a/packages/sdk/test/await.test.ts
+++ b/packages/sdk/test/await.test.ts
@@ -2,19 +2,18 @@ import { match, rejects, strictEqual } from "assert";
 import { describe, test } from "mocha";
 import {
   type AsyncFunction,
-  getAbortSignal,
+  type PollingController,
+  createPollingController,
   getAsyncPoller,
-  type SignalAndInterval,
 } from "../src/helpers/await.js";
 import { getDelay } from "../src/helpers/utils.js";
 
 describe("await", function () {
   test("ensure polling stops after successful results", async function () {
     let callCount = 0;
-    async function testPolling({
-      signal,
-      interval,
-    }: SignalAndInterval = {}): Promise<boolean> {
+    async function testPolling(
+      controller: PollingController
+    ): Promise<boolean> {
       let first = true;
       const fn: AsyncFunction<boolean> = async () => {
         callCount += 1;
@@ -25,50 +24,47 @@ describe("await", function () {
         await getDelay(10);
         return { done: true, data: true };
       };
-      return await getAsyncPoller(fn, interval, signal);
+      return await getAsyncPoller(fn, controller);
     }
-    const controller = new AbortController();
-    const signal = controller.signal;
-    await testPolling({ signal, interval: 10 });
-    await getDelay(1000);
+    await testPolling(createPollingController(10000, 100));
     strictEqual(callCount, 2);
   });
 
   test("ensure polling stops after timeout", async function () {
-    async function testPolling({
-      signal,
-      interval,
-    }: SignalAndInterval = {}): Promise<boolean> {
+    async function testPolling(
+      controller: PollingController
+    ): Promise<boolean> {
       const fn: AsyncFunction<boolean> = async () => {
         return { done: false };
       };
-      return await getAsyncPoller(fn, interval, signal);
+      return await getAsyncPoller(fn, controller);
     }
-    const controller = new AbortController();
-    const signal = controller.signal;
+    const controller = createPollingController(1000, 10);
     setTimeout(() => controller.abort(), 5);
-    await rejects(testPolling({ signal, interval: 10 }), (err: any) => {
+    await rejects(testPolling(controller), (err: any) => {
       match(err.message, /Th(e|is) operation was aborted/);
       return true;
     });
   });
 
-  test("getAbortSignal returns a valid signal", async function () {
-    const controller = new AbortController();
-    const initial = controller.signal;
-    const { signal } = getAbortSignal(initial, 10);
-    strictEqual(signal.aborted, false);
+  test("createAbort returns a valid signal", async function () {
+    // Check aborted flag
+    const controller = createPollingController();
+    strictEqual(controller.signal.aborted, false);
     controller.abort();
-    strictEqual(signal.aborted, true);
-    strictEqual(initial.aborted, true);
-    const { signal: third } = getAbortSignal(undefined, 10);
-    strictEqual(third.aborted, false);
+    strictEqual(controller.signal.aborted, true);
+    // Check signal event listener
+    const controller2 = createPollingController();
+    strictEqual(controller2.signal.aborted, false);
+    setTimeout(() => {
+      controller2.abort();
+    }, 1000);
     await new Promise<void>(function (resolve) {
-      third.addEventListener("abort", function abortListener() {
-        third.removeEventListener("abort", abortListener);
+      controller2.signal.addEventListener("abort", function abortListener() {
+        controller2.signal.removeEventListener("abort", abortListener);
         resolve();
       });
     });
-    strictEqual(third.aborted, true);
+    strictEqual(controller2.signal.aborted, true);
   });
 });

--- a/packages/sdk/test/await.test.ts
+++ b/packages/sdk/test/await.test.ts
@@ -9,6 +9,18 @@ import {
 import { getDelay } from "../src/helpers/utils.js";
 
 describe("await", function () {
+  test("ensure default polling controller timeout and interval", function () {
+    const controller = createPollingController();
+    strictEqual(controller.timeout, 60000);
+    strictEqual(controller.interval, 1500);
+  });
+
+  test("ensure custom polling controller timeout and interval", function () {
+    const controller = createPollingController(999, 10);
+    strictEqual(controller.timeout, 999);
+    strictEqual(controller.interval, 10);
+  });
+
   test("ensure polling stops after successful results", async function () {
     let callCount = 0;
     async function testPolling(

--- a/packages/sdk/test/chains.test.ts
+++ b/packages/sdk/test/chains.test.ts
@@ -9,6 +9,7 @@ import {
   type ChainName,
   supportedChains,
   overrideDefaults,
+  getChainPollingController,
 } from "../src/helpers/chains.js";
 import { TEST_VALIDATOR_URL } from "./setup";
 
@@ -26,7 +27,9 @@ describe("chains", function () {
       strictEqual(getBaseUrl("optimism"), mainnet);
       strictEqual(getBaseUrl("mainnet"), mainnet);
     });
+  });
 
+  describe("getContractAddress()", function () {
     test("where we check the known default localhost contract address", async function () {
       const localhost = "0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512";
       const matic = "0x5c4e6A9e5C1e1BF445A062006faF19EA6c49aFeA";
@@ -40,7 +43,9 @@ describe("chains", function () {
         matic.toLowerCase()
       );
     });
+  });
 
+  describe("isTestnet()", function () {
     test("where we make sure a testnet is correctly flagged", function () {
       const testnets: ChainName[] = [
         "sepolia",
@@ -63,14 +68,18 @@ describe("chains", function () {
         strictEqual(isTestnet(net), false);
       }
     });
+  });
 
+  describe("supportedChains", function () {
     test("where we make sure supportedChains is a valid object", function () {
       strictEqual(Object.keys(supportedChains).length >= 12, true);
       strictEqual(Object.keys(supportedChains).includes("mainnet"), true);
       strictEqual(Object.keys(supportedChains).includes("maticmum"), true);
       strictEqual(Object.keys(supportedChains).includes("localhost"), true);
     });
+  });
 
+  describe("getChainId()", function () {
     test("where ensure we have a default set of chains with ids", function () {
       // Mainnets
       strictEqual(getChainId("mainnet"), 1);
@@ -89,7 +98,9 @@ describe("chains", function () {
       // Local
       strictEqual(getChainId("localhost"), 31337);
     });
+  });
 
+  describe("getChainInfo()", function () {
     test("where spot check a few chain info objects", function () {
       const localhostUrl = TEST_VALIDATOR_URL;
       const testnetsUrl = "https://testnets.tableland.network/api/v1";
@@ -127,6 +138,66 @@ describe("chains", function () {
             err.message,
             "cannot use unsupported chain: 999999999999"
           );
+          return true;
+        }
+      );
+    });
+  });
+
+  describe("getChainPollingController()", function () {
+    test("where we get polling controller with chain ids", async function () {
+      const homesteadController = getChainPollingController(1); // mainnet
+      const filecoinController = getChainPollingController(314); // filecoin
+      const maticmumController = getChainPollingController(80001); // polygon mumbai
+      const filecoinTestnetController = getChainPollingController(314159); // filecoin testnet
+      const localController = getChainPollingController(31337); // local
+      strictEqual(homesteadController.interval, 1500); // most should use the same 1500ms interval
+      strictEqual(homesteadController.timeout, 40000); // but different timeouts
+      strictEqual(filecoinController.interval, 5000); // filecoin has longer intervals
+      strictEqual(filecoinController.timeout, 210000);
+      strictEqual(maticmumController.interval, 1500);
+      strictEqual(maticmumController.timeout, 15000);
+      strictEqual(filecoinTestnetController.interval, 5000);
+      strictEqual(filecoinTestnetController.timeout, 210000);
+      strictEqual(localController.interval, 1500);
+      strictEqual(localController.timeout, 5000);
+      homesteadController.cancel();
+      filecoinController.cancel();
+      maticmumController.cancel();
+      filecoinTestnetController.cancel();
+      localController.cancel();
+    });
+
+    test("where we get polling controller with chain names", async function () {
+      const homesteadController = getChainPollingController("homestead");
+      const filecoinTestnetController = getChainPollingController(
+        "filecoin-calibration"
+      );
+      const localController = getChainPollingController("local-tableland");
+      strictEqual(homesteadController.interval, 1500);
+      strictEqual(homesteadController.timeout, 40000);
+      strictEqual(filecoinTestnetController.interval, 5000);
+      strictEqual(filecoinTestnetController.timeout, 210000);
+      strictEqual(localController.interval, 1500);
+      strictEqual(localController.timeout, 5000);
+      homesteadController.cancel();
+      filecoinTestnetController.cancel();
+      localController.cancel();
+    });
+
+    test("when called with invalid chain name or id", async function () {
+      throws(
+        // @ts-expect-error need to tell ts to ignore this since we are testing a failure when used without ts
+        () => getChainPollingController("invalid"),
+        (err: any) => {
+          strictEqual(err.message, "cannot use unsupported chain: invalid");
+          return true;
+        }
+      );
+      throws(
+        () => getChainPollingController(99999),
+        (err: any) => {
+          strictEqual(err.message, "cannot use unsupported chain: 99999");
           return true;
         }
       );

--- a/packages/sdk/test/database.test.ts
+++ b/packages/sdk/test/database.test.ts
@@ -68,7 +68,9 @@ describe("database", function () {
         .prepare(
           "CREATE TABLE test_batch (id integer, name text, age integer, primary key (id));"
         )
-        .all(undefined, createPollingController(TEST_TIMEOUT_FACTOR * 60000));
+        .all({
+          controller: createPollingController(TEST_TIMEOUT_FACTOR * 60000),
+        });
       tableName = meta.txn?.name ?? "";
       deepStrictEqual(results, []);
       strictEqual(error, undefined);
@@ -554,7 +556,7 @@ describe("database", function () {
         .prepare(
           "CREATE TABLE test_exec (id integer, name text, age integer, primary key (id));"
         )
-        .run(controller);
+        .run({ controller });
       tableName = meta.txn?.name ?? "";
       deepStrictEqual(results, []);
       strictEqual(error, undefined);

--- a/packages/sdk/test/lowlevel.test.ts
+++ b/packages/sdk/test/lowlevel.test.ts
@@ -18,7 +18,7 @@ import {
 } from "../src/lowlevel.js";
 import { extractReadonly } from "../src/registry/utils.js";
 import { getDelay } from "../src/helpers/utils.js";
-import { getAbortSignal } from "../src/helpers/await.js";
+import { createPollingController } from "../src/helpers/await.js";
 import { TEST_TIMEOUT_FACTOR, TEST_PROVIDER_URL } from "./setup";
 
 // Just to test out these functions
@@ -53,11 +53,7 @@ describe("lowlevel", function () {
           tables: ["test_exec"],
         }
       );
-      const { signal } = getAbortSignal(undefined, TEST_TIMEOUT_FACTOR * 30000);
-      await txn.wait({
-        signal,
-        interval: TEST_TIMEOUT_FACTOR * 1500,
-      });
+      await txn.wait(createPollingController(TEST_TIMEOUT_FACTOR * 30000));
       strictEqual(txn.error, undefined);
       match(txn.name, /^test_exec_31337_\d+$/);
       const { name } = await txn.wait();
@@ -168,9 +164,9 @@ describe("lowlevel", function () {
         tableName = txn.name ?? "";
         // For testing purposes, we abort the wait before we even start
         // This is ok, because we'll await the next transaction
-        const controller = new AbortController();
+        const controller = createPollingController();
         controller.abort();
-        await txn.wait({ signal: controller.signal }).catch(() => {});
+        await txn.wait(controller).catch(() => {});
       }
       {
         const txn = await exec(
@@ -224,14 +220,13 @@ describe("lowlevel", function () {
     });
 
     test("when using an abort controller to halt a query", async function () {
-      const controller = new AbortController();
-      const signal = controller.signal;
+      const controller = createPollingController();
       controller.abort();
       await rejects(
         queryAll(
           { baseUrl },
           `SELECT name, age FROM ${tableName} WHERE name='Bobby'`,
-          { signal }
+          controller
         ),
         (err: any) => {
           match(err.message, /Th(e|is) operation was aborted/);

--- a/packages/sdk/test/statement.test.ts
+++ b/packages/sdk/test/statement.test.ts
@@ -9,7 +9,10 @@ import assert, {
 import { describe, test } from "mocha";
 import { getAccounts } from "@tableland/local";
 import { getDelay } from "../src/helpers/utils.js";
-import { getDefaultProvider } from "../src/helpers/index.js";
+import {
+  createPollingController,
+  getDefaultProvider,
+} from "../src/helpers/index.js";
 import { Database, Statement } from "../src/index.js";
 import { TEST_TIMEOUT_FACTOR, TEST_PROVIDER_URL } from "./setup";
 
@@ -296,9 +299,9 @@ CREATE TABLE test_run (counter blurg);
           .run();
         tableName = meta.txn?.name ?? "";
         // For testing purposes, we abort the wait before we even start
-        const controller = new AbortController();
+        const controller = createPollingController();
         controller.abort();
-        await meta.txn?.wait({ signal: controller.signal }).catch(() => {});
+        await meta.txn?.wait(controller).catch(() => {});
       }
       {
         const { meta } = await db
@@ -351,10 +354,9 @@ SELECT * FROM 3.14;
       const stmt = db
         .prepare(`SELECT name, age FROM ${tableName} WHERE name=?`)
         .bind("Bobby");
-      const controller = new AbortController();
-      const signal = controller.signal;
+      const controller = createPollingController();
       controller.abort();
-      await rejects(stmt.all(undefined, { signal }), (err: any) => {
+      await rejects(stmt.all(undefined, controller), (err: any) => {
         match(err.cause.message, /Th(e|is) operation was aborted/);
         return true;
       });

--- a/packages/sdk/test/thirdparty.test.ts
+++ b/packages/sdk/test/thirdparty.test.ts
@@ -87,13 +87,13 @@ describe("thirdparty", function () {
 
       await result.meta.txn.wait();
 
+      // Use `all()` under the hood
       const { results } = await users.All({
         where: { name: "Bobby Tables" },
         limit: 1,
         offset: 0,
         orderBy: ["id"],
       });
-
       deepStrictEqual(results, [
         {
           name: "Bobby Tables",
@@ -101,6 +101,16 @@ describe("thirdparty", function () {
           email: "bobby-tab@gmail.com",
         },
       ]);
+
+      // Use `first()` under the hood
+      const first = await users.First({
+        where: { name: "Bobby Tables" },
+      });
+      deepStrictEqual(first, {
+        name: "Bobby Tables",
+        id: 1,
+        email: "bobby-tab@gmail.com",
+      });
     });
 
     test("basic query building works well to then query the data", async function () {


### PR DESCRIPTION
The initial work for this PR is located in https://github.com/tablelandnetwork/js-tableland/pull/576/files

_Summary
Fixes abort controller handling which allows a user to abort and configure the polling timeout and interval for SDK methods that poll the gateway for a receipt._

_Details
The core of this PR was adding the wiring to make the underlying polling handling aware of the user's abort controller. However, I found the API to be unintuitive and spent some time refactoring how a user goes about providing a abort-able controller with a custom timeout and polling interval. See comments below for details._

_NOTE: This would be a breaking API change and therefore would require a major version bump. We probably could make the core fix while not breaking the API, but I don't think there's any need to be bashful about frequently releasing new major versions at this point. What do you guys think?_