### PR TITLE
Export Schema and Column types so they can be used externally

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11969,24 +11969,24 @@
       "dev": true
     },
     "node_modules/typedoc": {
-      "version": "0.24.8",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.24.8.tgz",
-      "integrity": "sha512-ahJ6Cpcvxwaxfu4KtjA8qZNqS43wYt6JL27wYiIgl1vd38WW/KWX11YuAeZhuz9v+ttrutSsgK+XO1CjL1kA3w==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.25.1.tgz",
+      "integrity": "sha512-c2ye3YUtGIadxN2O6YwPEXgrZcvhlZ6HlhWZ8jQRNzwLPn2ylhdGqdR8HbyDRyALP8J6lmSANILCkkIdNPFxqA==",
       "dev": true,
       "dependencies": {
         "lunr": "^2.3.9",
         "marked": "^4.3.0",
-        "minimatch": "^9.0.0",
+        "minimatch": "^9.0.3",
         "shiki": "^0.14.1"
       },
       "bin": {
         "typedoc": "bin/typedoc"
       },
       "engines": {
-        "node": ">= 14.14"
+        "node": ">= 16"
       },
       "peerDependencies": {
-        "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x"
+        "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x || 5.2.x"
       }
     },
     "node_modules/typedoc/node_modules/brace-expansion": {
@@ -12660,7 +12660,7 @@
         "@tableland/sqlparser": "^1.3.0",
         "cli-select-2": "^2.0.0",
         "cosmiconfig": "^8.0.0",
-        "data-uri-to-buffer": "^4.0.1",
+        "data-uri-to-buffer": "^5.0.1",
         "dotenv": "^16.0.3",
         "ethers": "^5.7.1",
         "inquirer": "^9.1.2",
@@ -12895,7 +12895,7 @@
     },
     "packages/local": {
       "name": "@tableland/local",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -12951,7 +12951,7 @@
     },
     "packages/sdk": {
       "name": "@tableland/sdk",
-      "version": "4.5.0",
+      "version": "4.5.1",
       "license": "MIT AND Apache-2.0",
       "dependencies": {
         "@async-generators/from-emitter": "^0.3.0",
@@ -12966,7 +12966,7 @@
         "@playwright/test": "^1.30.0",
         "d1-orm": "^0.7.1",
         "openapi-typescript": "6.2.4",
-        "typedoc": "^0.24.6"
+        "typedoc": "^0.25.0"
       }
     }
   },
@@ -14387,7 +14387,7 @@
         "@types/yargs": "17.0.19",
         "cli-select-2": "^2.0.0",
         "cosmiconfig": "^8.0.0",
-        "data-uri-to-buffer": "^4.0.1",
+        "data-uri-to-buffer": "^5.0.1",
         "dotenv": "^16.0.3",
         "ethers": "^5.7.1",
         "inquirer": "^9.1.2",
@@ -14576,7 +14576,7 @@
         "d1-orm": "^0.7.1",
         "ethers": "^5.7.2",
         "openapi-typescript": "6.2.4",
-        "typedoc": "^0.24.6"
+        "typedoc": "^0.25.0"
       }
     },
     "@tableland/sqlparser": {
@@ -21936,14 +21936,14 @@
       "dev": true
     },
     "typedoc": {
-      "version": "0.24.8",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.24.8.tgz",
-      "integrity": "sha512-ahJ6Cpcvxwaxfu4KtjA8qZNqS43wYt6JL27wYiIgl1vd38WW/KWX11YuAeZhuz9v+ttrutSsgK+XO1CjL1kA3w==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.25.1.tgz",
+      "integrity": "sha512-c2ye3YUtGIadxN2O6YwPEXgrZcvhlZ6HlhWZ8jQRNzwLPn2ylhdGqdR8HbyDRyALP8J6lmSANILCkkIdNPFxqA==",
       "dev": true,
       "requires": {
         "lunr": "^2.3.9",
         "marked": "^4.3.0",
-        "minimatch": "^9.0.0",
+        "minimatch": "^9.0.3",
         "shiki": "^0.14.1"
       },
       "dependencies": {

--- a/packages/sdk/src/validator/index.ts
+++ b/packages/sdk/src/validator/index.ts
@@ -7,7 +7,7 @@ import {
 } from "../helpers/index.js";
 import { getHealth } from "./health.js";
 import { getVersion, type Version } from "./version.js";
-import { getTable, type Table, type Params as TableParams } from "./tables.js";
+import { getTable, type Table, type Params as TableParams, type Column, type Schema } from "./tables.js";
 import {
   getQuery,
   type Params as QueryParams,
@@ -29,6 +29,8 @@ export {
   type TableFormat,
   type ObjectsFormat,
   type QueryParams,
+  type Column,
+  type Schema,
 };
 
 /**

--- a/packages/sdk/src/validator/index.ts
+++ b/packages/sdk/src/validator/index.ts
@@ -7,7 +7,13 @@ import {
 } from "../helpers/index.js";
 import { getHealth } from "./health.js";
 import { getVersion, type Version } from "./version.js";
-import { getTable, type Table, type Params as TableParams, type Column, type Schema } from "./tables.js";
+import {
+  getTable,
+  type Table,
+  type Params as TableParams,
+  type Column,
+  type Schema,
+} from "./tables.js";
 import {
   getQuery,
   type Params as QueryParams,

--- a/packages/sdk/src/validator/tables.ts
+++ b/packages/sdk/src/validator/tables.ts
@@ -15,9 +15,9 @@ import {
 export type Params =
   Paths["/tables/{chainId}/{tableId}"]["get"]["parameters"]["path"];
 
-type Column = Components["schemas"]["Column"];
+export type Column = Components["schemas"]["Column"];
 type BaseSchema = Components["schemas"]["Schema"];
-interface Schema extends BaseSchema {
+export interface Schema extends BaseSchema {
   readonly columns: Array<PartialRequired<Column, "constraints">>;
 }
 


### PR DESCRIPTION
Can't use the `Schema` type without this.

I was trying to use `type Schema = Table["schema"]` and then exporting things that use `Schema`, but of course got a ts error that the SDK's internal `Schema` type can't be named, which makes sense since it wasn't exported.

Figure we might as well export `Column` as well.