### PR TITLE
Bump the sdk version with the already published patch v4.5.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12951,7 +12951,7 @@
     },
     "packages/sdk": {
       "name": "@tableland/sdk",
-      "version": "4.5.1",
+      "version": "4.5.2",
       "license": "MIT AND Apache-2.0",
       "dependencies": {
         "@async-generators/from-emitter": "^0.3.0",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tableland/sdk",
-  "version": "4.5.1",
+  "version": "4.5.2",
   "description": "A database client and helpers for the Tableland network",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
We missed updating the sdk version in #39. We did the publish already with this version, so we need to update `main`