### PR TITLE
(sdk) add helper to create studio project aliases

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tableland/sdk",
-  "version": "4.5.3-dev.0",
+  "version": "4.6.0-pre.0",
   "description": "A database client and helpers for the Tableland network",
   "publishConfig": {
     "access": "public"

--- a/packages/sdk/src/helpers/index.ts
+++ b/packages/sdk/src/helpers/index.ts
@@ -28,6 +28,7 @@ export {
   extractSigner,
   jsonFileAliases,
   prepReadConfig,
+  studioAliases,
 } from "./config.js";
 export {
   type Signer,


### PR DESCRIPTION
## Overview
This PR exposes a helper function that takes a Studio project ID and returns an aliases Object that can be used to instantiate a DB which uses the given project's table names.

## Details
The end goal here is to make the SDK _feel_ like a normal database, specifically table names don't need their universally unique suffixes.  A dev can create a project in the Studio, then simply instantiate Databases with the projectId.
e.g. `new Database({ projectId: "123-xyz" });`

### This is a first draft and there's a few things to consider:

I ended up calling the config param `projectId`.  The names `environmentId`, and `databaseId` are being discussed as well.  For this draft I landed on `projectId` for the following reasons:
- The term Environment doesn't exist in the Studio and using it seemed like I was adding unecessary complexity.
- The term Database seems overloaded, and also doesn't exist in the Studio.
- The project page is where people will end up looking for the projectId.
- The existing api endpoint that returns the name mapping we want is `deployments.projectDeployments`, which takes a `projectId` argument.

I did write some tests to make development of the feature easier, but they only work when the tests can connect to the studio with pre-populated data.  I used a personal test wallet and created projects on the current production studio, but I'm `skip`ping the tests here because the studio instance url and data might change as we develop and having access to the wallet in github ci is not trivial.  For now the tests only serve as an example usage.

The `@tableland/studio-client`  package is going to need to be published.  As an alternative to this PR, we could export this feature as a function in the `@tableland/studio-client` package. thoughts?