### PR TITLE
Expose a Local Tableland method that restarts the validator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12683,6 +12683,17 @@
         "tempy": "^3.0.0"
       }
     },
+    "packages/cli/node_modules/@tableland/sdk": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/@tableland/sdk/-/sdk-4.5.2.tgz",
+      "integrity": "sha512-fshBi0tyRGhLQY3C23XlGpbdrD2bPGiCFnOgGf7W83S6vB1aELM3yTMaVuQslmkwOcTW4bzSkzlq4TMPd0LR4A==",
+      "dependencies": {
+        "@async-generators/from-emitter": "^0.3.0",
+        "@tableland/evm": "^4.3.0",
+        "@tableland/sqlparser": "^1.3.0",
+        "ethers": "^5.7.2"
+      }
+    },
     "packages/cli/node_modules/ansi-escapes": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -12895,7 +12906,7 @@
     },
     "packages/local": {
       "name": "@tableland/local",
-      "version": "2.0.2",
+      "version": "2.1.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -12912,6 +12923,17 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "packages/local/node_modules/@tableland/sdk": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/@tableland/sdk/-/sdk-4.5.2.tgz",
+      "integrity": "sha512-fshBi0tyRGhLQY3C23XlGpbdrD2bPGiCFnOgGf7W83S6vB1aELM3yTMaVuQslmkwOcTW4bzSkzlq4TMPd0LR4A==",
+      "dependencies": {
+        "@async-generators/from-emitter": "^0.3.0",
+        "@tableland/evm": "^4.3.0",
+        "@tableland/sqlparser": "^1.3.0",
+        "ethers": "^5.7.2"
       }
     },
     "packages/local/node_modules/cliui": {
@@ -12951,7 +12973,7 @@
     },
     "packages/sdk": {
       "name": "@tableland/sdk",
-      "version": "4.5.2",
+      "version": "4.5.3-dev.0",
       "license": "MIT AND Apache-2.0",
       "dependencies": {
         "@async-generators/from-emitter": "^0.3.0",
@@ -14401,6 +14423,17 @@
         "yargs": "^17.6.2"
       },
       "dependencies": {
+        "@tableland/sdk": {
+          "version": "4.5.2",
+          "resolved": "https://registry.npmjs.org/@tableland/sdk/-/sdk-4.5.2.tgz",
+          "integrity": "sha512-fshBi0tyRGhLQY3C23XlGpbdrD2bPGiCFnOgGf7W83S6vB1aELM3yTMaVuQslmkwOcTW4bzSkzlq4TMPd0LR4A==",
+          "requires": {
+            "@async-generators/from-emitter": "^0.3.0",
+            "@tableland/evm": "^4.3.0",
+            "@tableland/sqlparser": "^1.3.0",
+            "ethers": "^5.7.2"
+          }
+        },
         "ansi-escapes": {
           "version": "4.3.2",
           "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -14538,6 +14571,17 @@
         "yargs": "^17.5.1"
       },
       "dependencies": {
+        "@tableland/sdk": {
+          "version": "4.5.2",
+          "resolved": "https://registry.npmjs.org/@tableland/sdk/-/sdk-4.5.2.tgz",
+          "integrity": "sha512-fshBi0tyRGhLQY3C23XlGpbdrD2bPGiCFnOgGf7W83S6vB1aELM3yTMaVuQslmkwOcTW4bzSkzlq4TMPd0LR4A==",
+          "requires": {
+            "@async-generators/from-emitter": "^0.3.0",
+            "@tableland/evm": "^4.3.0",
+            "@tableland/sqlparser": "^1.3.0",
+            "ethers": "^5.7.2"
+          }
+        },
         "cliui": {
           "version": "8.0.1",
           "requires": {

--- a/packages/local/package.json
+++ b/packages/local/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tableland/local",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "description": "Tooling to start a sandboxed Tableland network.",
   "repository": "https://github.com/tablelandnetwork/local-tableland",
   "license": "MIT",


### PR DESCRIPTION
## Overview
Hardhat has an RPC API that contains methods to take a snapshot of the chain state, and then revert to a given state.
Docs are here: https://hardhat.org/hardhat-network/docs/reference#evm_snapshot
This is useful for testing contracts, but the local tableland network becomes out of sync when this happens because the tables materialized by the Validator are no longer valid.
This PR enables local tableland users who want to snapshot and revert to do so in a way that keeps the Validator up to date with the reverted chain state.

## Details
The mechanism used here to re-sync the validator with the chain is to simple shutdown and restart the validator.  The methods needed to accomplish that haven't been public, so this PR simply does a small refactor and exposes a new method called `restartValidator`.
