### PR TITLE
fix: filter out `optimism-goerli-staging` from chains

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12656,7 +12656,7 @@
       "license": "MIT AND Apache-2.0",
       "dependencies": {
         "@ensdomains/ensjs": "3.0.0-alpha.64",
-        "@tableland/sdk": "^4.4.2",
+        "@tableland/sdk": "^4.5.3",
         "@tableland/sqlparser": "^1.3.0",
         "cli-select-2": "^2.0.0",
         "cosmiconfig": "^8.0.0",
@@ -12681,17 +12681,6 @@
         "mock-stdin": "^1.0.0",
         "sinon": "^15.0.1",
         "tempy": "^3.0.0"
-      }
-    },
-    "packages/cli/node_modules/@tableland/sdk": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/@tableland/sdk/-/sdk-4.5.2.tgz",
-      "integrity": "sha512-fshBi0tyRGhLQY3C23XlGpbdrD2bPGiCFnOgGf7W83S6vB1aELM3yTMaVuQslmkwOcTW4bzSkzlq4TMPd0LR4A==",
-      "dependencies": {
-        "@async-generators/from-emitter": "^0.3.0",
-        "@tableland/evm": "^4.3.0",
-        "@tableland/sqlparser": "^1.3.0",
-        "ethers": "^5.7.2"
       }
     },
     "packages/cli/node_modules/ansi-escapes": {
@@ -12910,7 +12899,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@tableland/sdk": "^4.4.2",
+        "@tableland/sdk": "^4.5.3",
         "@tableland/validator": "^1.8.1",
         "cross-spawn": "^7.0.3",
         "enquirer": "^2.3.6",
@@ -12923,17 +12912,6 @@
       },
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "packages/local/node_modules/@tableland/sdk": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/@tableland/sdk/-/sdk-4.5.2.tgz",
-      "integrity": "sha512-fshBi0tyRGhLQY3C23XlGpbdrD2bPGiCFnOgGf7W83S6vB1aELM3yTMaVuQslmkwOcTW4bzSkzlq4TMPd0LR4A==",
-      "dependencies": {
-        "@async-generators/from-emitter": "^0.3.0",
-        "@tableland/evm": "^4.3.0",
-        "@tableland/sqlparser": "^1.3.0",
-        "ethers": "^5.7.2"
       }
     },
     "packages/local/node_modules/cliui": {
@@ -12973,7 +12951,7 @@
     },
     "packages/sdk": {
       "name": "@tableland/sdk",
-      "version": "4.5.3-dev.0",
+      "version": "4.5.3",
       "license": "MIT AND Apache-2.0",
       "dependencies": {
         "@async-generators/from-emitter": "^0.3.0",
@@ -14401,7 +14379,7 @@
       "version": "file:packages/cli",
       "requires": {
         "@ensdomains/ensjs": "3.0.0-alpha.64",
-        "@tableland/sdk": "^4.4.2",
+        "@tableland/sdk": "^4.5.3",
         "@tableland/sqlparser": "^1.3.0",
         "@types/cosmiconfig": "^6.0.0",
         "@types/js-yaml": "^4.0.5",
@@ -14424,8 +14402,7 @@
       },
       "dependencies": {
         "@tableland/sdk": {
-          "version": "4.5.2",
-          "resolved": "https://registry.npmjs.org/@tableland/sdk/-/sdk-4.5.2.tgz",
+          "version": "https://registry.npmjs.org/@tableland/sdk/-/sdk-4.5.2.tgz",
           "integrity": "sha512-fshBi0tyRGhLQY3C23XlGpbdrD2bPGiCFnOgGf7W83S6vB1aELM3yTMaVuQslmkwOcTW4bzSkzlq4TMPd0LR4A==",
           "requires": {
             "@async-generators/from-emitter": "^0.3.0",
@@ -14562,7 +14539,7 @@
     "@tableland/local": {
       "version": "file:packages/local",
       "requires": {
-        "@tableland/sdk": "^4.4.2",
+        "@tableland/sdk": "^4.5.3",
         "@tableland/validator": "^1.8.1",
         "cross-spawn": "^7.0.3",
         "enquirer": "^2.3.6",
@@ -14571,17 +14548,6 @@
         "yargs": "^17.5.1"
       },
       "dependencies": {
-        "@tableland/sdk": {
-          "version": "4.5.2",
-          "resolved": "https://registry.npmjs.org/@tableland/sdk/-/sdk-4.5.2.tgz",
-          "integrity": "sha512-fshBi0tyRGhLQY3C23XlGpbdrD2bPGiCFnOgGf7W83S6vB1aELM3yTMaVuQslmkwOcTW4bzSkzlq4TMPd0LR4A==",
-          "requires": {
-            "@async-generators/from-emitter": "^0.3.0",
-            "@tableland/evm": "^4.3.0",
-            "@tableland/sqlparser": "^1.3.0",
-            "ethers": "^5.7.2"
-          }
-        },
         "cliui": {
           "version": "8.0.1",
           "requires": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -54,7 +54,7 @@
   },
   "dependencies": {
     "@ensdomains/ensjs": "3.0.0-alpha.64",
-    "@tableland/sdk": "^4.4.2",
+    "@tableland/sdk": "^4.5.3",
     "@tableland/sqlparser": "^1.3.0",
     "cli-select-2": "^2.0.0",
     "cosmiconfig": "^8.0.0",

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -3,6 +3,7 @@ import { extname } from "path";
 import { Wallet, providers, getDefaultProvider } from "ethers";
 import { helpers } from "@tableland/sdk";
 
+// TODO: should be able to remove the "staging" filter since the SDK handles it
 export const getChains = function (): typeof helpers.supportedChains {
   return Object.fromEntries(
     Object.entries(helpers.supportedChains).filter(

--- a/packages/local/package.json
+++ b/packages/local/package.json
@@ -60,7 +60,7 @@
     "up:dev": "node dist/esm/up.js --validator ../go-tableland --registry ../evm-tableland"
   },
   "dependencies": {
-    "@tableland/sdk": "^4.4.2",
+    "@tableland/sdk": "^4.5.3",
     "@tableland/validator": "^1.8.1",
     "cross-spawn": "^7.0.3",
     "enquirer": "^2.3.6",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tableland/sdk",
-  "version": "4.5.3-dev.0",
+  "version": "4.5.3",
   "description": "A database client and helpers for the Tableland network",
   "publishConfig": {
     "access": "public"

--- a/packages/sdk/src/helpers/chains.ts
+++ b/packages/sdk/src/helpers/chains.ts
@@ -37,11 +37,15 @@ const mapped = entries.map(([chainName, contractAddress]) => {
   ];
   return entry;
 });
+// Filter out "optimism-goerli-staging"
+const filtered = mapped.filter(
+  ([chainName]) => chainName !== "optimism-goerli-staging"
+);
 
 /**
  * The set of chains and their information as supported by the Tableland network.
  */
-export const supportedChains = Object.fromEntries(mapped) as Record<
+export const supportedChains = Object.fromEntries(filtered) as Record<
   ChainName,
   ChainInfo
 >;

--- a/packages/sdk/test/chains.test.ts
+++ b/packages/sdk/test/chains.test.ts
@@ -72,11 +72,22 @@ describe("chains", function () {
     });
 
     test("where ensure we have a default set of chains with ids", function () {
+      // Mainnets
       strictEqual(getChainId("mainnet"), 1);
-      strictEqual(getChainId("localhost"), 31337);
-      strictEqual(getChainId("maticmum"), 80001);
+      strictEqual(getChainId("homestead"), 1);
+      strictEqual(getChainId("matic"), 137);
       strictEqual(getChainId("optimism"), 10);
       strictEqual(getChainId("arbitrum"), 42161);
+      strictEqual(getChainId("arbitrum-nova"), 42170);
+      strictEqual(getChainId("filecoin"), 314);
+      // Testnets
+      strictEqual(getChainId("sepolia"), 11155111);
+      strictEqual(getChainId("maticmum"), 80001);
+      strictEqual(getChainId("optimism-goerli"), 420);
+      strictEqual(getChainId("arbitrum-goerli"), 421613);
+      strictEqual(getChainId("filecoin-calibration"), 314159);
+      // Local
+      strictEqual(getChainId("localhost"), 31337);
     });
 
     test("where spot check a few chain info objects", function () {
@@ -93,6 +104,32 @@ describe("chains", function () {
       const maticmum = getChainInfo("maticmum");
       strictEqual(maticmum.baseUrl, testnetsUrl);
       strictEqual(maticmum.chainId, 80001);
+    });
+
+    test("where it fails when invalid chain is passed", function () {
+      // Should not exist for Optimism Goerli staging environment (filtered out)
+      throws(
+        () => getChainId("optimism-goerli-staging"),
+        (err: any) => {
+          strictEqual(
+            err.message,
+            "cannot use unsupported chain: optimism-goerli-staging"
+          );
+          return true;
+        }
+      );
+
+      // Try some random chain ID
+      throws(
+        () => getChainId(999999999999),
+        (err: any) => {
+          strictEqual(
+            err.message,
+            "cannot use unsupported chain: 999999999999"
+          );
+          return true;
+        }
+      );
     });
   });
 


### PR DESCRIPTION
## Summary

If you try to create a table on OP Goerli, it actually uses the `optimism-goerli-staging` network instead of `optimism-goerli`. This filters out the "staging" network and adds tests accordingly. Also, I squeezed in a dep bump for `@tableland/sdk`. Closes #58.

## Details

There's a simple one liner added to `helpers/chains.ts`:
```ts
const filtered = mapped.filter(
  ([chainName]) => chainName !== "optimism-goerli-staging"
);
```

This is then used in the `supportedChains` object, which gets exported and is used in clients like the CLI. Note that the CLI had to implement similar logic to what's described above. The change in the SDK will allow us to remove that check in the CLI, but it's not required at the moment; everything should still work as expected in the CLI.

Wrt to the `@tableland/sdk@^4.5.3-dev.0` dep bump, I also deleted `package-lock.json` and reinstalled the overall deps in root. It seems that lerna was having issues with symlinks, and deleting the lock file & updating the packages seemed to fix it. I think lerna might require that each package is using the latest version—e.g., in `packages/cli`, if I don't use `4.5.3-dev.0` but use any earlier SDK version, I cannot set up a symlink successfully.

## How it was tested

Added a test in `chains.test.ts` to make sure that `getChainId("optimism-goerli-staging")` will throw an error for `cannot use unsupported chain`.

I also set up a symlink to the Studio, and I successfully created a table on the _correct_ OP Goerli network.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
