### PR TITLE
(sdk) Add alias to file instead of overwriting

### DIFF
--- a/packages/sdk/src/helpers/config.ts
+++ b/packages/sdk/src/helpers/config.ts
@@ -111,7 +111,8 @@ export function jsonFileAliases(filepath: string): AliasesNameMap {
     },
     write: async function (nameMap: NameMapping) {
       const fs = await getFsModule();
-      fs.writeFileSync(filepath, JSON.stringify(nameMap));
+      const current = await this.read();
+      fs.writeFileSync(filepath, JSON.stringify({ ...current, ...nameMap }));
     },
   };
 }

--- a/packages/sdk/test/aliases.test.ts
+++ b/packages/sdk/test/aliases.test.ts
@@ -202,16 +202,19 @@ describe("aliases", function () {
     try {
       fs.mkdirSync(aliasesDir);
     } catch (err) {}
-    // reset the aliases file, and ensure the helper
-    // creates the file if it doesn't exist
-    try {
-      fs.unlinkSync(aliasesFile);
-    } catch (err) {}
 
     const db = new Database({
       signer,
       // use the built-in SDK helper to setup and manage json aliases files
       aliases: jsonFileAliases(aliasesFile),
+    });
+
+    beforeEach(function () {
+      // reset the aliases file, and ensure the helper
+      // creates the file if it doesn't exist
+      try {
+        fs.unlinkSync(aliasesFile);
+      } catch (err) {}
     });
 
     this.afterAll(function () {
@@ -230,6 +233,30 @@ describe("aliases", function () {
       const nameMap = (await db.config.aliases?.read()) ?? {};
 
       strictEqual(nameMap[tablePrefix], uuTableName);
+    });
+
+    test("running create statement updates existing aliases", async function () {
+      const tablePrefix1 = "json_aliases_table1";
+      const tablePrefix2 = "json_aliases_table2";
+      const { meta: meta1 } = await db
+        .prepare(`CREATE TABLE ${tablePrefix1} (counter int, info text);`)
+        .all();
+
+      const uuTableName1 = meta1.txn?.name ?? "";
+      const nameMap1 = (await db.config.aliases?.read()) ?? {};
+
+      strictEqual(nameMap1[tablePrefix1], uuTableName1);
+      strictEqual(nameMap1[tablePrefix2], undefined);
+
+      const { meta: meta2 } = await db
+        .prepare(`CREATE TABLE ${tablePrefix2} (counter int, info text);`)
+        .all();
+
+      const uuTableName2 = meta2.txn?.name ?? "";
+      const nameMap2 = (await db.config.aliases?.read()) ?? {};
+
+      strictEqual(nameMap2[tablePrefix1], uuTableName1);
+      strictEqual(nameMap2[tablePrefix2], uuTableName2);
     });
   });
 });


### PR DESCRIPTION
This current aliases config helper will overwrite any existing aliases file when you create a new table.  This was an oversight during initial development.  This PR changes the behaviour to add to the file as new tables are created.