### PR TITLE
refactor: D1 API conformance

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -184,6 +184,14 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
+    "node_modules/@cloudflare/workers-types": {
+      "version": "4.20231025.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20231025.0.tgz",
+      "integrity": "sha512-TkcZkntUTOcvJ4vgmwpNfLTclpMbmbClZCe62B25/VTukmyv91joRa4eKzSjzCZUXTbFHNmVdOpmGaaJU2U3+A==",
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
@@ -4475,6 +4483,92 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/drizzle-orm": {
+      "version": "0.28.6",
+      "resolved": "https://registry.npmjs.org/drizzle-orm/-/drizzle-orm-0.28.6.tgz",
+      "integrity": "sha512-yBe+F9htrlYER7uXgDJUQsTHFoIrI5yMm5A0bg0GiZ/kY5jNXTWoEy4KQtg35cE27sw1VbgzoMWHAgCckUUUww==",
+      "dev": true,
+      "peerDependencies": {
+        "@aws-sdk/client-rds-data": ">=3",
+        "@cloudflare/workers-types": ">=3",
+        "@libsql/client": "*",
+        "@neondatabase/serverless": ">=0.1",
+        "@opentelemetry/api": "^1.4.1",
+        "@planetscale/database": ">=1",
+        "@types/better-sqlite3": "*",
+        "@types/pg": "*",
+        "@types/sql.js": "*",
+        "@vercel/postgres": "*",
+        "better-sqlite3": ">=7",
+        "bun-types": "*",
+        "knex": "*",
+        "kysely": "*",
+        "mysql2": ">=2",
+        "pg": ">=8",
+        "postgres": ">=3",
+        "sql.js": ">=1",
+        "sqlite3": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/client-rds-data": {
+          "optional": true
+        },
+        "@cloudflare/workers-types": {
+          "optional": true
+        },
+        "@libsql/client": {
+          "optional": true
+        },
+        "@neondatabase/serverless": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@planetscale/database": {
+          "optional": true
+        },
+        "@types/better-sqlite3": {
+          "optional": true
+        },
+        "@types/pg": {
+          "optional": true
+        },
+        "@types/sql.js": {
+          "optional": true
+        },
+        "@vercel/postgres": {
+          "optional": true
+        },
+        "better-sqlite3": {
+          "optional": true
+        },
+        "bun-types": {
+          "optional": true
+        },
+        "knex": {
+          "optional": true
+        },
+        "kysely": {
+          "optional": true
+        },
+        "mysql2": {
+          "optional": true
+        },
+        "pg": {
+          "optional": true
+        },
+        "postgres": {
+          "optional": true
+        },
+        "sql.js": {
+          "optional": true
+        },
+        "sqlite3": {
+          "optional": true
+        }
       }
     },
     "node_modules/duplexer": {
@@ -12965,6 +13059,7 @@
         "@ethersproject/experimental": "^5.7.0",
         "@playwright/test": "^1.30.0",
         "d1-orm": "^0.9.0",
+        "drizzle-orm": "^0.28.6",
         "openapi-typescript": "6.2.4",
         "typedoc": "^0.25.0"
       }
@@ -13084,6 +13179,14 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
+    },
+    "@cloudflare/workers-types": {
+      "version": "4.20231025.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20231025.0.tgz",
+      "integrity": "sha512-TkcZkntUTOcvJ4vgmwpNfLTclpMbmbClZCe62B25/VTukmyv91joRa4eKzSjzCZUXTbFHNmVdOpmGaaJU2U3+A==",
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "@cspotcode/source-map-support": {
       "version": "0.8.1",
@@ -14574,6 +14677,7 @@
         "@tableland/evm": "^4.4.0",
         "@tableland/sqlparser": "^1.3.0",
         "d1-orm": "^0.9.0",
+        "drizzle-orm": "^0.28.6",
         "ethers": "^5.7.2",
         "openapi-typescript": "6.2.4",
         "typedoc": "^0.25.0"
@@ -16358,6 +16462,13 @@
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
       "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
       "dev": true
+    },
+    "drizzle-orm": {
+      "version": "0.28.6",
+      "resolved": "https://registry.npmjs.org/drizzle-orm/-/drizzle-orm-0.28.6.tgz",
+      "integrity": "sha512-yBe+F9htrlYER7uXgDJUQsTHFoIrI5yMm5A0bg0GiZ/kY5jNXTWoEy4KQtg35cE27sw1VbgzoMWHAgCckUUUww==",
+      "dev": true,
+      "requires": {}
     },
     "duplexer": {
       "version": "0.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4075,9 +4075,9 @@
       }
     },
     "node_modules/d1-orm": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/d1-orm/-/d1-orm-0.8.0.tgz",
-      "integrity": "sha512-w6l+bA84Zc2JyoA8n2RaAt2lk65Ytze1Da3PzaJasjmK/ohpt/7HA29cz1rN7vh8Krmu6+NamQn7UYyptCXJaw==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/d1-orm/-/d1-orm-0.9.0.tgz",
+      "integrity": "sha512-avgEvxttrcpL/+vupernkH3CgT6rI5VI07XT5HwhD4x99fHs3WZ2SldnmTsduB701+dAuc4BEi4eQWkaPWRZKQ==",
       "dev": true
     },
     "node_modules/dargs": {
@@ -12964,7 +12964,7 @@
         "@databases/sql": "^3.2.0",
         "@ethersproject/experimental": "^5.7.0",
         "@playwright/test": "^1.30.0",
-        "d1-orm": "^0.8.0",
+        "d1-orm": "^0.9.0",
         "openapi-typescript": "6.2.4",
         "typedoc": "^0.25.0"
       }
@@ -14571,9 +14571,9 @@
         "@databases/sql": "^3.2.0",
         "@ethersproject/experimental": "^5.7.0",
         "@playwright/test": "^1.30.0",
-        "@tableland/evm": "4.4.0",
+        "@tableland/evm": "^4.4.0",
         "@tableland/sqlparser": "^1.3.0",
-        "d1-orm": "0.8.0",
+        "d1-orm": "^0.9.0",
         "ethers": "^5.7.2",
         "openapi-typescript": "6.2.4",
         "typedoc": "^0.25.0"
@@ -16087,9 +16087,9 @@
       }
     },
     "d1-orm": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/d1-orm/-/d1-orm-0.8.0.tgz",
-      "integrity": "sha512-w6l+bA84Zc2JyoA8n2RaAt2lk65Ytze1Da3PzaJasjmK/ohpt/7HA29cz1rN7vh8Krmu6+NamQn7UYyptCXJaw==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/d1-orm/-/d1-orm-0.9.0.tgz",
+      "integrity": "sha512-avgEvxttrcpL/+vupernkH3CgT6rI5VI07XT5HwhD4x99fHs3WZ2SldnmTsduB701+dAuc4BEi4eQWkaPWRZKQ==",
       "dev": true
     },
     "dargs": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4075,9 +4075,9 @@
       }
     },
     "node_modules/d1-orm": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/d1-orm/-/d1-orm-0.7.2.tgz",
-      "integrity": "sha512-s0s/RudLe7/BspbUf7ZwKe+0Eov5fFt0WVPVWdphx6kAWDMj0OTy9KaWockTOMVoI4XPGypiZ/wxK0kb+KVmSg==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/d1-orm/-/d1-orm-0.8.0.tgz",
+      "integrity": "sha512-w6l+bA84Zc2JyoA8n2RaAt2lk65Ytze1Da3PzaJasjmK/ohpt/7HA29cz1rN7vh8Krmu6+NamQn7UYyptCXJaw==",
       "dev": true
     },
     "node_modules/dargs": {
@@ -12964,7 +12964,7 @@
         "@databases/sql": "^3.2.0",
         "@ethersproject/experimental": "^5.7.0",
         "@playwright/test": "^1.30.0",
-        "d1-orm": "^0.7.1",
+        "d1-orm": "^0.8.0",
         "openapi-typescript": "6.2.4",
         "typedoc": "^0.25.0"
       }
@@ -14573,7 +14573,7 @@
         "@playwright/test": "^1.30.0",
         "@tableland/evm": "4.4.0",
         "@tableland/sqlparser": "^1.3.0",
-        "d1-orm": "^0.7.1",
+        "d1-orm": "0.8.0",
         "ethers": "^5.7.2",
         "openapi-typescript": "6.2.4",
         "typedoc": "^0.25.0"
@@ -16087,9 +16087,9 @@
       }
     },
     "d1-orm": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/d1-orm/-/d1-orm-0.7.2.tgz",
-      "integrity": "sha512-s0s/RudLe7/BspbUf7ZwKe+0Eov5fFt0WVPVWdphx6kAWDMj0OTy9KaWockTOMVoI4XPGypiZ/wxK0kb+KVmSg==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/d1-orm/-/d1-orm-0.8.0.tgz",
+      "integrity": "sha512-w6l+bA84Zc2JyoA8n2RaAt2lk65Ytze1Da3PzaJasjmK/ohpt/7HA29cz1rN7vh8Krmu6+NamQn7UYyptCXJaw==",
       "dev": true
     },
     "dargs": {

--- a/packages/local/test/e2e.test.ts
+++ b/packages/local/test/e2e.test.ts
@@ -37,7 +37,7 @@ describe("network end to end", function () {
     );
 
     const data = await db
-      .prepare(`SELECT * FROM ${res.meta.txn?.name as string};`)
+      .prepare(`SELECT * FROM ${res.txn?.name as string};`)
       .all();
     expect(data.results).to.eql([]);
   });

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -85,7 +85,7 @@
     "@databases/sql": "^3.2.0",
     "@ethersproject/experimental": "^5.7.0",
     "@playwright/test": "^1.30.0",
-    "d1-orm": "^0.8.0",
+    "d1-orm": "^0.9.0",
     "openapi-typescript": "6.2.4",
     "typedoc": "^0.25.0"
   },

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -86,6 +86,7 @@
     "@ethersproject/experimental": "^5.7.0",
     "@playwright/test": "^1.30.0",
     "d1-orm": "^0.9.0",
+    "drizzle-orm": "^0.28.6",
     "openapi-typescript": "6.2.4",
     "typedoc": "^0.25.0"
   },

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -85,7 +85,7 @@
     "@databases/sql": "^3.2.0",
     "@ethersproject/experimental": "^5.7.0",
     "@playwright/test": "^1.30.0",
-    "d1-orm": "^0.7.1",
+    "d1-orm": "^0.8.0",
     "openapi-typescript": "6.2.4",
     "typedoc": "^0.25.0"
   },

--- a/packages/sdk/src/helpers/await.ts
+++ b/packages/sdk/src/helpers/await.ts
@@ -150,3 +150,19 @@ export async function getAsyncPoller<T = unknown>(
   };
   return await new Promise<T>(checkCondition);
 }
+
+/**
+ * Check if an argument is a valid {@link PollingController}.
+ * @param arg The argument to check.
+ * @returns An assertion/boolean, indicating if the argument is valid.
+ */
+export function isPollingController(arg: any): arg is PollingController {
+  return (
+    arg != null &&
+    arg.signal instanceof AbortSignal &&
+    typeof arg.abort === "function" &&
+    typeof arg.interval === "number" &&
+    typeof arg.cancel === "function" &&
+    typeof arg.timeout === "number"
+  );
+}

--- a/packages/sdk/src/registry/index.ts
+++ b/packages/sdk/src/registry/index.ts
@@ -29,6 +29,7 @@ import {
 
 export {
   type Result,
+  type ExecResult,
   type Metadata,
   type WaitableTransactionReceipt,
   type Named,

--- a/packages/sdk/src/registry/utils.ts
+++ b/packages/sdk/src/registry/utils.ts
@@ -101,6 +101,7 @@ export function wrapResult<T = unknown>(
     meta,
     success: true,
     results: [],
+    error: undefined,
   };
   if (isTransactionReceipt(resultsOrReceipt)) {
     return { ...result, meta: { ...meta, txn: resultsOrReceipt } };
@@ -159,11 +160,13 @@ export interface Result<T = unknown> {
   /**
    * Whether the query or transaction was successful.
    */
-  success: boolean; // almost always true
+  success: true; // TODO: this is a bug in D1, but if we want to be compatible
+  //       we have to type it like this :<
+  //       https://github.com/cloudflare/workerd/issues/940
   /**
    * If there was an error, this will contain the error string.
    */
-  error?: string; // TODO: this changed to `never` in D1 API
+  error: undefined;
   /**
    * Additional meta information.
    */

--- a/packages/sdk/src/registry/utils.ts
+++ b/packages/sdk/src/registry/utils.ts
@@ -86,6 +86,12 @@ function isTransactionReceipt(arg: any): arg is WaitableTransactionReceipt {
   );
 }
 
+/**
+ * Wrap results for a Statement `run` or `all` call, or a Database `batch` call.
+ * @param resultsOrReceipt Either query results or the transaction receipt.
+ * @param duration Total client-side duration of the async call.
+ * @returns Wrapped results with metadata.
+ */
 export function wrapResult<T = unknown>(
   resultsOrReceipt: T[] | WaitableTransactionReceipt,
   duration: number
@@ -103,6 +109,28 @@ export function wrapResult<T = unknown>(
 }
 
 /**
+ * Wrap results for a Database `exec` call.
+ * @param result The result of the a {@link wrapResult} call, made by `exec` under the hood.
+ * @param count The count of executed statements.
+ * @returns Wrapped {@link ExecResult} with metadata and transaction
+ * receipt or query results.
+ */
+export function wrapExecResult<T = unknown>(
+  result: Result<T>,
+  count: number
+): ExecResult<T> {
+  const { duration } = result.meta;
+  const execResult: ExecResult<T> = {
+    count,
+    duration,
+  };
+  if (result.meta.txn != null) {
+    return { ...execResult, txn: result.meta.txn };
+  }
+  return { ...execResult, results: result.results };
+}
+
+/**
  * Metadata represents meta information about an executed statement/transaction.
  */
 export interface Metadata {
@@ -111,11 +139,11 @@ export interface Metadata {
    */
   duration: number;
   /**
-   * The optional transactionn information receipt.
+   * The optional transaction information receipt.
    */
   txn?: WaitableTransactionReceipt;
   /**
-   * Metadata may contrain additional arbitrary key/values pairs.
+   * Metadata may constrain additional arbitrary key/values pairs.
    */
   [key: string]: any;
 }
@@ -135,11 +163,26 @@ export interface Result<T = unknown> {
   /**
    * If there was an error, this will contain the error string.
    */
-  error?: string;
+  error?: string; // TODO: this changed to `never` in D1 API
   /**
    * Additional meta information.
    */
   meta: Metadata;
+}
+
+/**
+ * ExecResult represents the return result for executed Database statements via `exec()`.
+ */
+export interface ExecResult<T = unknown>
+  extends Pick<Metadata, "duration" | "txn"> {
+  /**
+   * The count of executed statements.
+   */
+  count: number;
+  /**
+   * The optional list of query results.
+   */
+  results?: T[];
 }
 
 export async function extractReadonly(

--- a/packages/sdk/src/statement.ts
+++ b/packages/sdk/src/statement.ts
@@ -232,7 +232,7 @@ export class Statement<S = unknown> {
    * Runs the query/queries, but returns no results. Instead, run()
    * returns the metrics only. Useful for write operations like
    * UPDATE, DELETE or INSERT.
-   * @param controller An optional object used to control behavior, see {@link Options}
+   * @param opts An optional object used to control behavior, see {@link Options}
    * @returns A results object with metadata only (results are null or an empty array).
    */
   async run<T = Record<string, S>>(opts: Options = {}): Promise<Result<T>> {
@@ -263,7 +263,7 @@ export class Statement<S = unknown> {
 
   /**
    * Same as stmt.all(), but returns an array of rows instead of objects.
-   * @param controller An optional object used to control behavior, see {@link Options}
+   * @param opts An optional object used to control behavior, see {@link Options}
    * @returns An array of raw query results.
    */
   async raw<T = S[]>(opts: Options = {}): Promise<Array<ValueOf<T>>> {

--- a/packages/sdk/src/statement.ts
+++ b/packages/sdk/src/statement.ts
@@ -266,7 +266,7 @@ export class Statement<S = unknown> {
    * @param opts An optional object used to control behavior, see {@link Options}
    * @returns An array of raw query results.
    */
-  async raw<T = S[]>(opts: Options = {}): Promise<Array<ValueOf<T>>> {
+  async raw<T = unknown>(opts: Options = {}): Promise<Array<ValueOf<T>>> {
     try {
       const { sql, type, tables } = await this.#parseAndExtract();
       switch (type) {

--- a/packages/sdk/src/statement.ts
+++ b/packages/sdk/src/statement.ts
@@ -153,7 +153,7 @@ export class Statement<S = unknown> {
    * Executes a query and returns all rows and metadata.
    * @param opts An optional object used to control behavior, see {@link Options}
    */
-  async all<T = S>(opts: Options = {}): Promise<Result<T>> {
+  async all<T = Record<string, S>>(opts: Options = {}): Promise<Result<T>> {
     try {
       const start = performance.now();
       const { sql, type, tables } = await this.#parseAndExtract();
@@ -187,13 +187,7 @@ export class Statement<S = unknown> {
    * @param colName If provided, filter results to the provided column.
    * @param opts An optional object used to control behavior, see {@link Options}
    */
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  async first<T = S, K extends keyof T = keyof T>(opts?: Options): Promise<T>;
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  async first<T = S, K extends keyof T = keyof T>(
-    colName: undefined,
-    opts?: Options
-  ): Promise<T>;
+  async first<T = Record<string, S>>(opts?: Options): Promise<T | null>;
   async first<T = S, K extends keyof T = keyof T>(
     colName: K,
     opts?: Options
@@ -241,7 +235,7 @@ export class Statement<S = unknown> {
    * @param controller An optional object used to control behavior, see {@link Options}
    * @returns A results object with metadata only (results are null or an empty array).
    */
-  async run(opts: Options = {}): Promise<Result<never>> {
+  async run<T = Record<string, S>>(opts: Options = {}): Promise<Result<T>> {
     try {
       const start = performance.now();
       const { sql, type, tables } = await this.#parseAndExtract();
@@ -272,7 +266,7 @@ export class Statement<S = unknown> {
    * @param controller An optional object used to control behavior, see {@link Options}
    * @returns An array of raw query results.
    */
-  async raw<T = S>(opts: Options = {}): Promise<Array<ValueOf<T>>> {
+  async raw<T = S[]>(opts: Options = {}): Promise<Array<ValueOf<T>>> {
     try {
       const { sql, type, tables } = await this.#parseAndExtract();
       switch (type) {

--- a/packages/sdk/src/statement.ts
+++ b/packages/sdk/src/statement.ts
@@ -282,7 +282,7 @@ export class Statement<S = unknown> {
    * @param opts An optional object used to control behavior, see {@link Options}
    * @returns An array of raw query results.
    */
-  async raw<T = unknown>(opts: Options = {}): Promise<Array<ValueOf<T>>> {
+  async raw<T = S>(opts: Options = {}): Promise<Array<ValueOf<T>>> {
     try {
       const { sql, type, tables } = await this.#parseAndExtract();
       switch (type) {

--- a/packages/sdk/test/chains.test.ts
+++ b/packages/sdk/test/chains.test.ts
@@ -204,6 +204,66 @@ describe("chains", function () {
     });
   });
 
+  describe("getChainPollingController()", function () {
+    test("where we get polling controller with chain ids", async function () {
+      const homesteadController = getChainPollingController(1); // mainnet
+      const filecoinController = getChainPollingController(314); // filecoin
+      const maticmumController = getChainPollingController(80001); // polygon mumbai
+      const filecoinTestnetController = getChainPollingController(314159); // filecoin testnet
+      const localController = getChainPollingController(31337); // local
+      strictEqual(homesteadController.interval, 1500); // most should use the same 1500ms interval
+      strictEqual(homesteadController.timeout, 40000); // but different timeouts
+      strictEqual(filecoinController.interval, 5000); // filecoin has longer intervals
+      strictEqual(filecoinController.timeout, 210000);
+      strictEqual(maticmumController.interval, 1500);
+      strictEqual(maticmumController.timeout, 15000);
+      strictEqual(filecoinTestnetController.interval, 5000);
+      strictEqual(filecoinTestnetController.timeout, 210000);
+      strictEqual(localController.interval, 1500);
+      strictEqual(localController.timeout, 5000);
+      homesteadController.cancel();
+      filecoinController.cancel();
+      maticmumController.cancel();
+      filecoinTestnetController.cancel();
+      localController.cancel();
+    });
+
+    test("where we get polling controller with chain names", async function () {
+      const homesteadController = getChainPollingController("homestead");
+      const filecoinTestnetController = getChainPollingController(
+        "filecoin-calibration"
+      );
+      const localController = getChainPollingController("local-tableland");
+      strictEqual(homesteadController.interval, 1500);
+      strictEqual(homesteadController.timeout, 40000);
+      strictEqual(filecoinTestnetController.interval, 5000);
+      strictEqual(filecoinTestnetController.timeout, 210000);
+      strictEqual(localController.interval, 1500);
+      strictEqual(localController.timeout, 5000);
+      homesteadController.cancel();
+      filecoinTestnetController.cancel();
+      localController.cancel();
+    });
+
+    test("when called with invalid chain name or id", async function () {
+      throws(
+        // @ts-expect-error need to tell ts to ignore this since we are testing a failure when used without ts
+        () => getChainPollingController("invalid"),
+        (err: any) => {
+          strictEqual(err.message, "cannot use unsupported chain: invalid");
+          return true;
+        }
+      );
+      throws(
+        () => getChainPollingController(99999),
+        (err: any) => {
+          strictEqual(err.message, "cannot use unsupported chain: 99999");
+          return true;
+        }
+      );
+    });
+  });
+
   describe("overrideDefaults()", function () {
     test("when called incorrectly", async function () {
       throws(

--- a/packages/sdk/test/database.test.ts
+++ b/packages/sdk/test/database.test.ts
@@ -599,12 +599,12 @@ describe("database", function () {
     test("when executing mutations works and adds rows", async function () {
       const sql = `INSERT INTO ${tableName} (name, age) VALUES ('Bobby', 5);
       INSERT INTO ${tableName} (name, age) VALUES ('Tables', 6);`;
-      const { meta } = await db.exec(sql);
-      assert(meta.duration != null);
-      strictEqual(meta.count, 2);
-      assert(meta.txn != null);
+      const { duration, count, txn } = await db.exec(sql);
+      assert(duration != null);
+      strictEqual(count, 2);
+      assert(txn != null);
 
-      await meta.txn.wait();
+      await txn.wait();
 
       const results = await db.prepare("SELECT * FROM " + tableName).all();
       strictEqual(results.results.length, 2);
@@ -625,10 +625,10 @@ describe("database", function () {
       });
 
       test("when querying a table right after creation", async function () {
-        const { meta } = await db.exec(
+        const { txn } = await db.exec(
           "CREATE TABLE exec_nowait (keyy TEXT, vall TEXT);"
         );
-        const tableName = meta.txn?.name ?? "";
+        const tableName = txn?.name ?? "";
         match(tableName, /^exec_nowait_31337_\d+$/);
 
         const { results } = await db.exec(`SELECT * FROM ${tableName};`);
@@ -664,10 +664,10 @@ describe("database", function () {
         await meta.txn?.wait();
       }
       const sql = `SELECT name, age FROM ${tableName} WHERE name='Bobby';`;
-      const { meta } = await db.exec(sql);
-      strictEqual(meta.count, 1);
-      assert(meta.duration != null);
-      strictEqual(meta.txn, undefined);
+      const { count, duration, txn } = await db.exec(sql);
+      strictEqual(count, 1);
+      assert(duration != null);
+      strictEqual(txn, undefined);
     });
   });
 

--- a/packages/sdk/test/statement.test.ts
+++ b/packages/sdk/test/statement.test.ts
@@ -681,7 +681,7 @@ SELECT * FROM 3.14;
         const controller = createPollingController();
         const stmt = db.prepare(`SELECT * FROM ${tableName};`);
         const row = await stmt.first<{ counter: number; info: string }>(
-          // undefined,
+          undefined,
           {
             controller,
           }

--- a/packages/sdk/test/statement.test.ts
+++ b/packages/sdk/test/statement.test.ts
@@ -286,6 +286,29 @@ CREATE TABLE test_run (counter blurg);
 
       await meta.txn?.wait();
     });
+
+    describe("with options", function () {
+      test("when using an abort controller to halt a query", async function () {
+        const stmt = db.prepare(`SELECT * FROM ${tableName};`);
+        const controller = createPollingController();
+        controller.abort();
+        await rejects(stmt.run({ controller }), (err: any) => {
+          match(err.cause.message, /Th(e|is) operation was aborted/);
+          return true;
+        });
+      });
+
+      test("when using an abort controller and select statement is valid", async function () {
+        const controller = createPollingController();
+        const stmt = db.prepare(`SELECT * FROM ${tableName};`);
+        const { results, meta, error } = await stmt.run<{ counter: number }>({
+          controller,
+        });
+        strictEqual(error, undefined);
+        assert(meta.duration != null);
+        assert(results.length > 0);
+      });
+    });
   });
 
   describe(".all()", function () {
@@ -348,18 +371,6 @@ SELECT * FROM 3.14;
         { id: 3, counter: 3, info: "three" },
         { id: 4, counter: 4, info: "four" },
       ]);
-    });
-
-    test("when using an abort controller to halt a query", async function () {
-      const stmt = db
-        .prepare(`SELECT name, age FROM ${tableName} WHERE name=?`)
-        .bind("Bobby");
-      const controller = createPollingController();
-      controller.abort();
-      await rejects(stmt.all({ controller }), (err: any) => {
-        match(err.cause.message, /Th(e|is) operation was aborted/);
-        return true;
-      });
     });
 
     test("when trying to extract a missing column", async function () {
@@ -493,6 +504,34 @@ SELECT * FROM 3.14;
         db.config.autoWait = false;
       });
     });
+
+    describe("with options", function () {
+      test("when using an abort controller to halt a query", async function () {
+        const stmt = db
+          .prepare(`SELECT name, age FROM ${tableName} WHERE name=?`)
+          .bind("Bobby");
+        const controller = createPollingController();
+        controller.abort();
+        await rejects(stmt.all({ controller }), (err: any) => {
+          match(err.cause.message, /Th(e|is) operation was aborted/);
+          return true;
+        });
+      });
+
+      test("when using an abort controller and select statement is valid", async function () {
+        const controller = createPollingController();
+        const stmt = db.prepare(`SELECT * FROM ${tableName};`);
+        const { results, meta, error } = await stmt.all<{
+          counter: number;
+          info: string;
+        }>({
+          controller,
+        });
+        strictEqual(error, undefined);
+        assert(meta.duration != null);
+        assert(results.length > 0);
+      });
+    });
   });
 
   describe(".first()", function () {
@@ -564,6 +603,20 @@ SELECT * FROM 3.14;
       strictEqual(row, null);
     });
 
+    test("when select statement with colName of undefined is valid", async function () {
+      const stmt = db.prepare(`SELECT * FROM ${tableName};`);
+      const row = await stmt.first<{ counter: number; info: string }>(
+        undefined
+      );
+      deepStrictEqual(row, { counter: 1, info: "one" });
+    });
+
+    test("when select statement with colName of string is valid", async function () {
+      const stmt = db.prepare(`SELECT * FROM ${tableName};`);
+      const row = await stmt.first<{ counter: number }>("counter");
+      deepStrictEqual(row, [1]);
+    });
+
     describe("with autoWait turned on", function () {
       this.beforeAll(() => {
         db.config.autoWait = true;
@@ -575,6 +628,74 @@ SELECT * FROM 3.14;
       });
       this.afterAll(() => {
         db.config.autoWait = false;
+      });
+    });
+
+    describe("with options", function () {
+      test("when using an abort controller to halt a query with no colName param passed", async function () {
+        const stmt = db.prepare(`SELECT * FROM ${tableName};`);
+        const controller = createPollingController();
+        controller.abort();
+        await rejects(
+          stmt.first<{ counter: number; info: string }>({ controller }),
+          (err: any) => {
+            match(err.cause.message, /Th(e|is) operation was aborted/);
+            return true;
+          }
+        );
+      });
+
+      test("when using an abort controller to halt a query with colName as undefined", async function () {
+        const stmt = db.prepare(`SELECT * FROM ${tableName};`);
+        const controller = createPollingController();
+        controller.abort();
+        await rejects(stmt.first(undefined, { controller }), (err: any) => {
+          match(err.cause.message, /Th(e|is) operation was aborted/);
+          return true;
+        });
+      });
+
+      test("when using an abort controller to halt a query with colName as string", async function () {
+        const stmt = db.prepare(`SELECT * FROM ${tableName};`);
+        const controller = createPollingController();
+        controller.abort();
+        await rejects(
+          stmt.first<{ counter: number }>("counter", { controller }),
+          (err: any) => {
+            match(err.cause.message, /Th(e|is) operation was aborted/);
+            return true;
+          }
+        );
+      });
+
+      test("when using an abort controller and select with no colName param passed is valid", async function () {
+        const controller = createPollingController();
+        const stmt = db.prepare(`SELECT * FROM ${tableName};`);
+        const row = await stmt.first<{ counter: number; info: string }>({
+          controller,
+        });
+        deepStrictEqual(row, { counter: 1, info: "one" });
+      });
+
+      test("when using an abort controller and select with colName of undefined is valid", async function () {
+        const controller = createPollingController();
+        const stmt = db.prepare(`SELECT * FROM ${tableName};`);
+        const row = await stmt.first<{ counter: number; info: string }>(
+          // undefined,
+          {
+            controller,
+          }
+        );
+        deepStrictEqual(row, { counter: 1, info: "one" });
+      });
+
+      test("when using an abort controller and select with colName of string is valid", async function () {
+        const controller = createPollingController();
+        const stmt = db.prepare(`SELECT * FROM ${tableName};`);
+        const row = await stmt.first<{ counter: number }>("counter", {
+          controller,
+        });
+        deepStrictEqual(row, [1]);
       });
     });
   });
@@ -663,6 +784,31 @@ SELECT * FROM 3.14;
       });
       this.afterAll(() => {
         db.config.autoWait = false;
+      });
+    });
+
+    describe("with options", function () {
+      test("when using an abort controller to halt a query", async function () {
+        const stmt = db.prepare(`SELECT * FROM ${tableName};`);
+        const controller = createPollingController();
+        controller.abort();
+        await rejects(stmt.raw({ controller }), (err: any) => {
+          match(err.cause.message, /Th(e|is) operation was aborted/);
+          return true;
+        });
+      });
+
+      test("when using an abort controller and select statement is valid", async function () {
+        const controller = createPollingController();
+        const stmt = db.prepare(`SELECT * FROM ${tableName};`);
+        const results = await stmt.raw<{
+          id: number;
+          counter: number;
+          info: string;
+        }>({
+          controller,
+        });
+        assert(results.length > 0);
       });
     });
   });

--- a/packages/sdk/test/thirdparty.test.ts
+++ b/packages/sdk/test/thirdparty.test.ts
@@ -263,8 +263,7 @@ describe("thirdparty", function () {
     type User = InferSelectModel<typeof user>;
     type NewUser = InferInsertModel<typeof user>;
 
-    // @ts-expect-error Tableland database & D1Database type assignment warning
-    const database = drizzle<User>(db, { schema: user });
+    const database = drizzle(db, { schema: { user } });
 
     this.beforeAll(async function () {
       // Opt for SDK table create over Drizzle migration process for simplicity

--- a/packages/sdk/test/thirdparty.test.ts
+++ b/packages/sdk/test/thirdparty.test.ts
@@ -35,7 +35,8 @@ describe("thirdparty", function () {
   const baseSigner = wallet.connect(provider);
   // Also demonstrates the nonce manager usage
   const signer = new NonceManager(baseSigner);
-  // Name mapping is helpful for Drizzle ORM usage
+  // an `aliases` option is required for Drizzle ORM usage since D1 uses `exec`
+  // internally to do table creation, and we need to capture the uu table name
   const nameMap: NameMapping = {};
   const db = new Database({
     signer,
@@ -53,7 +54,6 @@ describe("thirdparty", function () {
   });
 
   describe("d1-orm", function () {
-    // @ts-expect-error Tableland database & D1Database type assignment warning
     const orm = new D1Orm(db);
 
     // We'll define our core model up here and use it in tests below
@@ -84,15 +84,9 @@ describe("thirdparty", function () {
     type User = Infer<typeof users>;
 
     this.beforeAll(async function () {
-      const create = await users.CreateTable({
+      await users.CreateTable({
         strategy: "default",
       });
-      // @ts-expect-error Tableland database & D1Database `ExecResult` type differences
-      await create.txn.wait();
-
-      // TODO: Find a nicer way to deal with this...
-      // @ts-expect-error Tableland database & D1Database `ExecResult` type differences
-      (users.tableName as any) = create.txn.name;
     });
 
     test("where a basic model is used to create data", async function () {

--- a/packages/sdk/test/thirdparty.test.ts
+++ b/packages/sdk/test/thirdparty.test.ts
@@ -2,14 +2,14 @@
 import { deepStrictEqual, strictEqual } from "assert";
 import { describe, test } from "mocha";
 import { getAccounts } from "@tableland/local";
-// import {
-//   D1Orm,
-//   DataTypes,
-//   Model,
-//   GenerateQuery,
-//   QueryType,
-//   type Infer,
-// } from "d1-orm";
+import {
+  D1Orm,
+  DataTypes,
+  Model,
+  GenerateQuery,
+  QueryType,
+  type Infer,
+} from "d1-orm";
 import sql, { type FormatConfig } from "@databases/sql";
 import { escapeSQLiteIdentifier } from "@databases/escape-identifier";
 import { NonceManager } from "@ethersproject/experimental";
@@ -29,14 +29,7 @@ describe("thirdparty", function () {
   const signer = new NonceManager(baseSigner);
   const db = new Database({ signer });
 
-  // NOTE: the d1-orm hasn't updated to the latest version of @cloudflare/workers-types
-  // I've opened PR to fix this, which will allow for `CreateTable` to work here
-  // since it uses `exec` under the hood, which now has a different return type
-  // https://github.com/Interactions-as-a-Service/d1-orm/pull/71
-
-  // TODO: Remove this once the above PR is merged
-  /*
-  describe.only("d1-orm", function () {
+  describe("d1-orm", function () {
     const orm = new D1Orm(db);
 
     // We'll define our core model up here and use it in tests below
@@ -46,6 +39,7 @@ describe("thirdparty", function () {
         tableName: "users",
         primaryKeys: "id",
         uniqueKeys: [["email"]],
+        withRowId: true, // If this is not set, `WITHOUT ROWID` will be attached and fail
       },
       {
         id: {
@@ -187,7 +181,6 @@ describe("thirdparty", function () {
       deepStrictEqual(results, user);
     });
   });
-  */
 
   describe("@databases/sql", function () {
     // See https://www.atdatabases.org/docs/sqlite

--- a/packages/sdk/test/thirdparty.test.ts
+++ b/packages/sdk/test/thirdparty.test.ts
@@ -2,14 +2,14 @@
 import { deepStrictEqual, strictEqual } from "assert";
 import { describe, test } from "mocha";
 import { getAccounts } from "@tableland/local";
-import {
-  D1Orm,
-  DataTypes,
-  Model,
-  GenerateQuery,
-  QueryType,
-  type Infer,
-} from "d1-orm";
+// import {
+//   D1Orm,
+//   DataTypes,
+//   Model,
+//   GenerateQuery,
+//   QueryType,
+//   type Infer,
+// } from "d1-orm";
 import sql, { type FormatConfig } from "@databases/sql";
 import { escapeSQLiteIdentifier } from "@databases/escape-identifier";
 import { NonceManager } from "@ethersproject/experimental";
@@ -29,7 +29,14 @@ describe("thirdparty", function () {
   const signer = new NonceManager(baseSigner);
   const db = new Database({ signer });
 
-  describe("d1-orm", function () {
+  // NOTE: the d1-orm hasn't updated to the latest version of @cloudflare/workers-types
+  // I've opened PR to fix this, which will allow for `CreateTable` to work here
+  // since it uses `exec` under the hood, which now has a different return type
+  // https://github.com/Interactions-as-a-Service/d1-orm/pull/71
+
+  // TODO: Remove this once the above PR is merged
+  /*
+  describe.only("d1-orm", function () {
     const orm = new D1Orm(db);
 
     // We'll define our core model up here and use it in tests below
@@ -62,10 +69,10 @@ describe("thirdparty", function () {
       const create = await users.CreateTable({
         strategy: "default",
       });
-      await create.meta.txn.wait();
+      await create.txn.wait();
 
       // TODO: Find a nicer way to deal with this...
-      (users.tableName as any) = create.meta.txn.name;
+      (users.tableName as any) = create.txn.name;
     });
 
     test("where a basic model is used to create data", async function () {
@@ -180,6 +187,7 @@ describe("thirdparty", function () {
       deepStrictEqual(results, user);
     });
   });
+  */
 
   describe("@databases/sql", function () {
     // See https://www.atdatabases.org/docs/sqlite


### PR DESCRIPTION
## Summary

The D1 API changed, so our API is no longer compatible. This introduces some breaking changes since some of the statement & database methods' parameters, generic types, and returned types have to be altered for conformance purposes.

## Details

For reference, [these are the old](https://github.com/cloudflare/workerd/commit/72d6915e19fb56de8373144bf922afa253b378cc) APIs, and [these are the new ones](https://github.com/cloudflare/workerd/blob/main/types/defines/d1.d.ts). The interfaces the statement methods must conform to are the following—notice the generic type `T = unknown` is now `T = Record<string, unknown>` in most of these:

```ts
// old
bind(...values: any[]): D1PreparedStatement;
first<T = unknown>(colName?: string): Promise<T>;
run<T = unknown>(): Promise<D1Result<T>>;
all<T = unknown>(): Promise<D1Result<T>>;
raw<T = unknown>(): Promise<T[]>;

// new
bind(...values: unknown[]): D1PreparedStatement;
first<T = unknown>(colName: string): Promise<T | null>;
first<T = Record<string, unknown>>(): Promise<T | null>;
run<T = Record<string, unknown>>(): Promise<D1Result<T>>;
all<T = Record<string, unknown>>(): Promise<D1Result<T>>;
raw<T = unknown[]>(): Promise<T[]>;
```

None of the database methods have changed, except for `exec`, which now has a custom return type:

```ts
// old
interface D1Result<T = unknown> {
  results?: T[];
  success: boolean;
  error?: string;
  meta: any;
}
exec<T = unknown>(query: string): Promise<D1Result<T>>;

// new
interface D1ExecResult {
  count: number;
  duration: number;
}
exec(query: string): Promise<D1ExecResult>;
```

So, a new `ExecResult` interface has been added for the `exec` method's return type, which includes the required `count` and `duration` as well as optional `txn` and `results` (see below).

From a DX perspective, the following changes should be noted. It wasn't clear if all of these changes were necessary as I was simply comparing and trying to go 1:1 to the new D1 API:
- Removed `colName` parameter for the statement methods, except `first`.
- Changed generic types for relevant statement methods to use `T = Record<string, S>` instead of `T = S`, where `S = unknown`.
- For `exec`, it no longer can use the same `Result` we had—a new `ExecResult` interface has been added, and a `wrapExecResult` properly formats the data for the `exec` return type.
  - This introduces one notable breaking change—since this interface only requires `count` and `duration`, the typical `meta` object cannot be required.
  - Thus, instead of a pattern for mutating queries like `await meta.txn?.wait()`, it looks like `await txn?.wait()`.

## How it was tested

Altered existing tests to take these changes into account. It primarily affected the `exec` method since it uses a new interface that doesn't contain `meta`.

Note: it looks like I also included a new test for `getChainPollingController`, which is more relevant to https://github.com/tablelandnetwork/tableland-js/pull/36.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
