### PR TITLE
chore: bump `cli`, `local` with patch version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12750,7 +12750,7 @@
     },
     "packages/cli": {
       "name": "@tableland/cli",
-      "version": "5.3.0",
+      "version": "5.3.1",
       "license": "MIT AND Apache-2.0",
       "dependencies": {
         "@ensdomains/ensjs": "3.0.0-alpha.64",
@@ -12994,7 +12994,7 @@
     },
     "packages/local": {
       "name": "@tableland/local",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "hasInstallScript": true,
       "license": "MIT AND Apache-2.0",
       "dependencies": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tableland/cli",
-  "version": "5.3.0",
+  "version": "5.3.1",
   "description": "Tableland command line tools",
   "repository": "https://github.com/tablelandnetwork/tableland-js",
   "publishConfig": {

--- a/packages/local/package.json
+++ b/packages/local/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tableland/local",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Tooling to start a sandboxed Tableland network.",
   "repository": "https://github.com/tablelandnetwork/tableland-js",
   "license": "MIT AND Apache-2.0",


### PR DESCRIPTION
## Summary

Updates the version for `cli` to `5.3.1` and `local` to `2.1.1`—both patch bumps.

## Details

Both packages had dep updates for the `@tableland/sdk@^5.0.0`. The CLI has a new `@tableland/node-helpers` dep along with some refactoring/bug fixes that don't impact the user.

## How it was tested

N/A

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
