### PR TITLE
fix(node-helpers|cli): `node-helpers` missing export

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12750,16 +12750,16 @@
     },
     "packages/cli": {
       "name": "@tableland/cli",
-      "version": "5.3.1",
+      "version": "5.3.2",
       "license": "MIT AND Apache-2.0",
       "dependencies": {
         "@ensdomains/ensjs": "3.0.0-alpha.64",
-        "@tableland/node-helpers": "^0.0.1",
+        "@tableland/node-helpers": "^0.0.2",
         "@tableland/sdk": "^5.0.0",
         "@tableland/sqlparser": "^1.3.0",
         "cli-select-2": "^2.0.0",
         "cosmiconfig": "^8.0.0",
-        "data-uri-to-buffer": "^5.0.1",
+        "data-uri-to-buffer": "^6.0.1",
         "dotenv": "^16.0.3",
         "ethers": "^5.7.1",
         "inquirer": "^9.1.2",
@@ -13050,7 +13050,7 @@
     },
     "packages/node-helpers": {
       "name": "@tableland/node-helpers",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "license": "MIT AND Apache-2.0",
       "devDependencies": {
         "@tableland/sdk": "^5.0.0",
@@ -14499,7 +14499,7 @@
       "version": "file:packages/cli",
       "requires": {
         "@ensdomains/ensjs": "3.0.0-alpha.64",
-        "@tableland/node-helpers": "^0.0.1",
+        "@tableland/node-helpers": "^0.0.2",
         "@tableland/sdk": "^5.0.0",
         "@tableland/sqlparser": "^1.3.0",
         "@types/cosmiconfig": "^6.0.0",
@@ -14508,7 +14508,7 @@
         "@types/yargs": "17.0.19",
         "cli-select-2": "^2.0.0",
         "cosmiconfig": "^8.0.0",
-        "data-uri-to-buffer": "^5.0.1",
+        "data-uri-to-buffer": "^6.0.1",
         "dotenv": "^16.0.3",
         "ethers": "^5.7.1",
         "inquirer": "^9.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1079,6 +1079,15 @@
         "@ethersproject/strings": "^5.7.0"
       }
     },
+    "node_modules/@fastify/busboy": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.0.0.tgz",
+      "integrity": "sha512-JUFJad5lv7jxj926GPgymrWQxxjPYuJNiNjNMzqT+HiuP6Vl3dk5xzG+8sTX96np0ZAluvaMzPsjhHZ5rNuNQQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@graphql-typed-document-node/core": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.2.0.tgz",
@@ -2058,9 +2067,9 @@
       }
     },
     "node_modules/@sinonjs/fake-timers": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
-      "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
+      "version": "11.2.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-11.2.2.tgz",
+      "integrity": "sha512-G2piCSxQ7oWOxwGSAyFHfPIsyeJGXYtc6mFbnFA+kRXkiEnTl8c/8jul2S329iFBnDI9HGoeWWAZvuvOkZccgw==",
       "dev": true,
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
@@ -2365,9 +2374,9 @@
       }
     },
     "node_modules/@types/sinon": {
-      "version": "10.0.15",
-      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-10.0.15.tgz",
-      "integrity": "sha512-3lrFNQG0Kr2LDzvjyjB6AMJk4ge+8iYhQfdnSwIwlG88FUOV43kPcQqDZkDa/h3WSZy6i8Fr0BSjfQtB1B3xuQ==",
+      "version": "10.0.20",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-10.0.20.tgz",
+      "integrity": "sha512-2APKKruFNCAZgx3daAyACGzWuJ028VVCUDk6o2rw/Z4PXT0ogwdV4KUegW0MwVs0Zu59auPXbbuBJHF12Sx1Eg==",
       "dev": true,
       "dependencies": {
         "@types/sinonjs__fake-timers": "*"
@@ -3230,18 +3239,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/busboy": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
-      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
-      "dev": true,
-      "dependencies": {
-        "streamsearch": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=10.16.0"
       }
     },
     "node_modules/byte-size": {
@@ -5517,9 +5514,9 @@
       "dev": true
     },
     "node_modules/fast-glob": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.0.tgz",
-      "integrity": "sha512-ChDuvbOypPuNjO8yIDf36x7BlZX1smcUMTTcyoIjycexOxd6DFsKsg21qVBzEmr3G7fUKIRy2/psii+CIUt7FA==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
+      "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
       "dev": true,
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -8718,9 +8715,9 @@
       "dev": true
     },
     "node_modules/nise": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.4.tgz",
-      "integrity": "sha512-8+Ib8rRJ4L0o3kfmyVCL7gzrohyDe0cMFTBa2d364yIrEGMEoetznKJx899YxjybU6bL9SQkYPSBBs1gyYs8Xg==",
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.5.tgz",
+      "integrity": "sha512-VJuPIfUFaXNRzETTQEEItTOP8Y171ijr+JLq42wHes3DiryR8vT+1TXQW/Rx8JNUhyYYWyIvjXTU6dOhJcs9Nw==",
       "dev": true,
       "dependencies": {
         "@sinonjs/commons": "^2.0.0",
@@ -8734,6 +8731,24 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-2.0.0.tgz",
       "integrity": "sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==",
+      "dev": true,
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/nise/node_modules/@sinonjs/fake-timers": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
+      "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.0"
+      }
+    },
+    "node_modules/nise/node_modules/@sinonjs/fake-timers/node_modules/@sinonjs/commons": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.0.tgz",
+      "integrity": "sha512-jXBtWAF4vmdNmZgD5FoKsVLv3rPgDnLgPbU84LIJ3otV44vJlDRokVng5v8NFJdCf/da9legHcKaRuZs4L7faA==",
       "dev": true,
       "dependencies": {
         "type-detect": "4.0.8"
@@ -9438,53 +9453,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/openapi-typescript": {
-      "version": "6.2.4",
-      "resolved": "https://registry.npmjs.org/openapi-typescript/-/openapi-typescript-6.2.4.tgz",
-      "integrity": "sha512-P/VK7oJ3TnIS67o1UzuS1pMnry4mzNzeQG0ZjLdPGT04mN9FeeTgHw1bN6MiANFN0tO6BcRavSL5tUFAh6iiwg==",
-      "dev": true,
-      "dependencies": {
-        "ansi-colors": "^4.1.3",
-        "fast-glob": "^3.2.12",
-        "js-yaml": "^4.1.0",
-        "supports-color": "^9.3.1",
-        "undici": "^5.22.0",
-        "yargs-parser": "^21.1.1"
-      },
-      "bin": {
-        "openapi-typescript": "bin/cli.js"
-      }
-    },
-    "node_modules/openapi-typescript/node_modules/ansi-colors": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
-      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/openapi-typescript/node_modules/supports-color": {
-      "version": "9.4.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-9.4.0.tgz",
-      "integrity": "sha512-VL+lNrEoIXww1coLPOmiEmK/0sGigko5COxI09KzHc2VJXJsQ37UaQ+8quuxjDeA7+KnLGTWRyOXSLLR2Wb4jw==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
-    "node_modules/openapi-typescript/node_modules/yargs-parser": {
-      "version": "21.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/optionator": {
@@ -11136,16 +11104,16 @@
       }
     },
     "node_modules/sinon": {
-      "version": "15.2.0",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-15.2.0.tgz",
-      "integrity": "sha512-nPS85arNqwBXaIsFCkolHjGIkFo+Oxu9vbgmBJizLAhqe6P2o3Qmj3KCUoRkfhHtvgDhZdWD3risLHAUJ8npjw==",
+      "version": "17.0.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-17.0.1.tgz",
+      "integrity": "sha512-wmwE19Lie0MLT+ZYNpDymasPHUKTaZHUH/pKEubRXIzySv9Atnlw+BUMGCzWgV7b7wO+Hw6f1TEOr0IUnmU8/g==",
       "dev": true,
       "dependencies": {
         "@sinonjs/commons": "^3.0.0",
-        "@sinonjs/fake-timers": "^10.3.0",
+        "@sinonjs/fake-timers": "^11.2.2",
         "@sinonjs/samsam": "^8.0.0",
         "diff": "^5.1.0",
-        "nise": "^5.1.4",
+        "nise": "^5.1.5",
         "supports-color": "^7.2.0"
       },
       "funding": {
@@ -11378,15 +11346,6 @@
         "error-stack-parser": "^1.3.6",
         "stack-generator": "^1.0.7",
         "stacktrace-gps": "^2.4.3"
-      }
-    },
-    "node_modules/streamsearch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
-      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
-      "dev": true,
-      "engines": {
-        "node": ">=10.0.0"
       }
     },
     "node_modules/string_decoder": {
@@ -12169,12 +12128,12 @@
       }
     },
     "node_modules/undici": {
-      "version": "5.22.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.22.1.tgz",
-      "integrity": "sha512-Ji2IJhFXZY0x/0tVBXeQwgPlLWw13GVzpsWPQ3rV50IFMMof2I55PZZxtm4P6iNq+L5znYN9nSTAq0ZyE6lSJw==",
+      "version": "5.27.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.27.2.tgz",
+      "integrity": "sha512-iS857PdOEy/y3wlM3yRp+6SNQQ6xU0mmZcwRSriqk+et/cwWAtwmIGf6WkoDN2EK/AMdCO/dfXzIwi+rFMrjjQ==",
       "dev": true,
       "dependencies": {
-        "busboy": "^1.6.0"
+        "@fastify/busboy": "^2.0.0"
       },
       "engines": {
         "node": ">=14.0"
@@ -12775,10 +12734,10 @@
       "devDependencies": {
         "@types/cosmiconfig": "^6.0.0",
         "@types/js-yaml": "^4.0.5",
-        "@types/sinon": "^10.0.13",
-        "@types/yargs": "17.0.19",
+        "@types/sinon": "^10.0.20",
+        "@types/yargs": "^17.0.19",
         "mock-stdin": "^1.0.0",
-        "sinon": "^15.0.1",
+        "sinon": "^17.0.1",
         "tempy": "^3.0.0"
       }
     },
@@ -13079,6 +13038,53 @@
         "drizzle-orm": "^0.28.6",
         "openapi-typescript": "6.2.4",
         "typedoc": "^0.25.0"
+      }
+    },
+    "packages/sdk/node_modules/ansi-colors": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "packages/sdk/node_modules/openapi-typescript": {
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/openapi-typescript/-/openapi-typescript-6.2.4.tgz",
+      "integrity": "sha512-P/VK7oJ3TnIS67o1UzuS1pMnry4mzNzeQG0ZjLdPGT04mN9FeeTgHw1bN6MiANFN0tO6BcRavSL5tUFAh6iiwg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-colors": "^4.1.3",
+        "fast-glob": "^3.2.12",
+        "js-yaml": "^4.1.0",
+        "supports-color": "^9.3.1",
+        "undici": "^5.22.0",
+        "yargs-parser": "^21.1.1"
+      },
+      "bin": {
+        "openapi-typescript": "bin/cli.js"
+      }
+    },
+    "packages/sdk/node_modules/supports-color": {
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-9.4.0.tgz",
+      "integrity": "sha512-VL+lNrEoIXww1coLPOmiEmK/0sGigko5COxI09KzHc2VJXJsQ37UaQ+8quuxjDeA7+KnLGTWRyOXSLLR2Wb4jw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "packages/sdk/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
       }
     }
   },
@@ -13753,6 +13759,12 @@
         "@ethersproject/properties": "^5.7.0",
         "@ethersproject/strings": "^5.7.0"
       }
+    },
+    "@fastify/busboy": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.0.0.tgz",
+      "integrity": "sha512-JUFJad5lv7jxj926GPgymrWQxxjPYuJNiNjNMzqT+HiuP6Vl3dk5xzG+8sTX96np0ZAluvaMzPsjhHZ5rNuNQQ==",
+      "dev": true
     },
     "@graphql-typed-document-node/core": {
       "version": "3.2.0",
@@ -14450,9 +14462,9 @@
       }
     },
     "@sinonjs/fake-timers": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
-      "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
+      "version": "11.2.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-11.2.2.tgz",
+      "integrity": "sha512-G2piCSxQ7oWOxwGSAyFHfPIsyeJGXYtc6mFbnFA+kRXkiEnTl8c/8jul2S329iFBnDI9HGoeWWAZvuvOkZccgw==",
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^3.0.0"
@@ -14504,8 +14516,8 @@
         "@tableland/sqlparser": "^1.3.0",
         "@types/cosmiconfig": "^6.0.0",
         "@types/js-yaml": "^4.0.5",
-        "@types/sinon": "^10.0.13",
-        "@types/yargs": "17.0.19",
+        "@types/sinon": "^10.0.20",
+        "@types/yargs": "^17.0.19",
         "cli-select-2": "^2.0.0",
         "cosmiconfig": "^8.0.0",
         "data-uri-to-buffer": "^6.0.1",
@@ -14516,7 +14528,7 @@
         "mock-stdin": "^1.0.0",
         "node-fetch": "^3.2.10",
         "readline": "^1.3.0",
-        "sinon": "^15.0.1",
+        "sinon": "^17.0.1",
         "table": "^6.8.1",
         "tempy": "^3.0.0",
         "yargs": "^17.6.2"
@@ -14706,6 +14718,40 @@
         "ethers": "^5.7.2",
         "openapi-typescript": "6.2.4",
         "typedoc": "^0.25.0"
+      },
+      "dependencies": {
+        "ansi-colors": {
+          "version": "4.1.3",
+          "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+          "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
+          "dev": true
+        },
+        "openapi-typescript": {
+          "version": "6.2.4",
+          "resolved": "https://registry.npmjs.org/openapi-typescript/-/openapi-typescript-6.2.4.tgz",
+          "integrity": "sha512-P/VK7oJ3TnIS67o1UzuS1pMnry4mzNzeQG0ZjLdPGT04mN9FeeTgHw1bN6MiANFN0tO6BcRavSL5tUFAh6iiwg==",
+          "dev": true,
+          "requires": {
+            "ansi-colors": "^4.1.3",
+            "fast-glob": "^3.2.12",
+            "js-yaml": "^4.1.0",
+            "supports-color": "^9.3.1",
+            "undici": "^5.22.0",
+            "yargs-parser": "^21.1.1"
+          }
+        },
+        "supports-color": {
+          "version": "9.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-9.4.0.tgz",
+          "integrity": "sha512-VL+lNrEoIXww1coLPOmiEmK/0sGigko5COxI09KzHc2VJXJsQ37UaQ+8quuxjDeA7+KnLGTWRyOXSLLR2Wb4jw==",
+          "dev": true
+        },
+        "yargs-parser": {
+          "version": "21.1.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+          "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+          "dev": true
+        }
       }
     },
     "@tableland/sqlparser": {
@@ -14931,9 +14977,9 @@
       }
     },
     "@types/sinon": {
-      "version": "10.0.15",
-      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-10.0.15.tgz",
-      "integrity": "sha512-3lrFNQG0Kr2LDzvjyjB6AMJk4ge+8iYhQfdnSwIwlG88FUOV43kPcQqDZkDa/h3WSZy6i8Fr0BSjfQtB1B3xuQ==",
+      "version": "10.0.20",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-10.0.20.tgz",
+      "integrity": "sha512-2APKKruFNCAZgx3daAyACGzWuJ028VVCUDk6o2rw/Z4PXT0ogwdV4KUegW0MwVs0Zu59auPXbbuBJHF12Sx1Eg==",
       "dev": true,
       "requires": {
         "@types/sinonjs__fake-timers": "*"
@@ -15565,15 +15611,6 @@
       "dev": true,
       "requires": {
         "run-applescript": "^5.0.0"
-      }
-    },
-    "busboy": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
-      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
-      "dev": true,
-      "requires": {
-        "streamsearch": "^1.1.0"
       }
     },
     "byte-size": {
@@ -17198,9 +17235,9 @@
       "dev": true
     },
     "fast-glob": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.0.tgz",
-      "integrity": "sha512-ChDuvbOypPuNjO8yIDf36x7BlZX1smcUMTTcyoIjycexOxd6DFsKsg21qVBzEmr3G7fUKIRy2/psii+CIUt7FA==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
+      "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
       "dev": true,
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -19590,9 +19627,9 @@
       "dev": true
     },
     "nise": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.4.tgz",
-      "integrity": "sha512-8+Ib8rRJ4L0o3kfmyVCL7gzrohyDe0cMFTBa2d364yIrEGMEoetznKJx899YxjybU6bL9SQkYPSBBs1gyYs8Xg==",
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.5.tgz",
+      "integrity": "sha512-VJuPIfUFaXNRzETTQEEItTOP8Y171ijr+JLq42wHes3DiryR8vT+1TXQW/Rx8JNUhyYYWyIvjXTU6dOhJcs9Nw==",
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^2.0.0",
@@ -19609,6 +19646,26 @@
           "dev": true,
           "requires": {
             "type-detect": "4.0.8"
+          }
+        },
+        "@sinonjs/fake-timers": {
+          "version": "10.3.0",
+          "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
+          "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
+          "dev": true,
+          "requires": {
+            "@sinonjs/commons": "^3.0.0"
+          },
+          "dependencies": {
+            "@sinonjs/commons": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.0.tgz",
+              "integrity": "sha512-jXBtWAF4vmdNmZgD5FoKsVLv3rPgDnLgPbU84LIJ3otV44vJlDRokVng5v8NFJdCf/da9legHcKaRuZs4L7faA==",
+              "dev": true,
+              "requires": {
+                "type-detect": "4.0.8"
+              }
+            }
           }
         }
       }
@@ -20130,40 +20187,6 @@
         "define-lazy-prop": "^2.0.0",
         "is-docker": "^2.1.1",
         "is-wsl": "^2.2.0"
-      }
-    },
-    "openapi-typescript": {
-      "version": "6.2.4",
-      "resolved": "https://registry.npmjs.org/openapi-typescript/-/openapi-typescript-6.2.4.tgz",
-      "integrity": "sha512-P/VK7oJ3TnIS67o1UzuS1pMnry4mzNzeQG0ZjLdPGT04mN9FeeTgHw1bN6MiANFN0tO6BcRavSL5tUFAh6iiwg==",
-      "dev": true,
-      "requires": {
-        "ansi-colors": "^4.1.3",
-        "fast-glob": "^3.2.12",
-        "js-yaml": "^4.1.0",
-        "supports-color": "^9.3.1",
-        "undici": "^5.22.0",
-        "yargs-parser": "^21.1.1"
-      },
-      "dependencies": {
-        "ansi-colors": {
-          "version": "4.1.3",
-          "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
-          "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "9.4.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-9.4.0.tgz",
-          "integrity": "sha512-VL+lNrEoIXww1coLPOmiEmK/0sGigko5COxI09KzHc2VJXJsQ37UaQ+8quuxjDeA7+KnLGTWRyOXSLLR2Wb4jw==",
-          "dev": true
-        },
-        "yargs-parser": {
-          "version": "21.1.1",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-          "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-          "dev": true
-        }
       }
     },
     "optionator": {
@@ -21354,16 +21377,16 @@
       }
     },
     "sinon": {
-      "version": "15.2.0",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-15.2.0.tgz",
-      "integrity": "sha512-nPS85arNqwBXaIsFCkolHjGIkFo+Oxu9vbgmBJizLAhqe6P2o3Qmj3KCUoRkfhHtvgDhZdWD3risLHAUJ8npjw==",
+      "version": "17.0.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-17.0.1.tgz",
+      "integrity": "sha512-wmwE19Lie0MLT+ZYNpDymasPHUKTaZHUH/pKEubRXIzySv9Atnlw+BUMGCzWgV7b7wO+Hw6f1TEOr0IUnmU8/g==",
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^3.0.0",
-        "@sinonjs/fake-timers": "^10.3.0",
+        "@sinonjs/fake-timers": "^11.2.2",
         "@sinonjs/samsam": "^8.0.0",
         "diff": "^5.1.0",
-        "nise": "^5.1.4",
+        "nise": "^5.1.5",
         "supports-color": "^7.2.0"
       },
       "dependencies": {
@@ -21560,12 +21583,6 @@
         "stack-generator": "^1.0.7",
         "stacktrace-gps": "^2.4.3"
       }
-    },
-    "streamsearch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
-      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
-      "dev": true
     },
     "string_decoder": {
       "version": "1.3.0",
@@ -22145,12 +22162,12 @@
       }
     },
     "undici": {
-      "version": "5.22.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.22.1.tgz",
-      "integrity": "sha512-Ji2IJhFXZY0x/0tVBXeQwgPlLWw13GVzpsWPQ3rV50IFMMof2I55PZZxtm4P6iNq+L5znYN9nSTAq0ZyE6lSJw==",
+      "version": "5.27.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.27.2.tgz",
+      "integrity": "sha512-iS857PdOEy/y3wlM3yRp+6SNQQ6xU0mmZcwRSriqk+et/cwWAtwmIGf6WkoDN2EK/AMdCO/dfXzIwi+rFMrjjQ==",
       "dev": true,
       "requires": {
-        "busboy": "^1.6.0"
+        "@fastify/busboy": "^2.0.0"
       }
     },
     "unique-filename": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tableland/cli",
-  "version": "5.3.1",
+  "version": "5.3.2",
   "description": "Tableland command line tools",
   "repository": "https://github.com/tablelandnetwork/tableland-js",
   "publishConfig": {
@@ -54,7 +54,7 @@
   },
   "dependencies": {
     "@ensdomains/ensjs": "3.0.0-alpha.64",
-    "@tableland/node-helpers": "^0.0.1",
+    "@tableland/node-helpers": "^0.0.2",
     "@tableland/sdk": "^5.0.0",
     "@tableland/sqlparser": "^1.3.0",
     "cli-select-2": "^2.0.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -46,10 +46,10 @@
   "devDependencies": {
     "@types/cosmiconfig": "^6.0.0",
     "@types/js-yaml": "^4.0.5",
-    "@types/sinon": "^10.0.13",
-    "@types/yargs": "17.0.19",
+    "@types/sinon": "^10.0.20",
+    "@types/yargs": "^17.0.19",
     "mock-stdin": "^1.0.0",
-    "sinon": "^15.0.1",
+    "sinon": "^17.0.1",
     "tempy": "^3.0.0"
   },
   "dependencies": {

--- a/packages/node-helpers/package.json
+++ b/packages/node-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tableland/node-helpers",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Helpers for the @tableland/sdk in a Node.js environment",
   "repository": "https://github.com/tablelandnetwork/tableland-js",
   "license": "MIT AND Apache-2.0",

--- a/packages/node-helpers/src/index.ts
+++ b/packages/node-helpers/src/index.ts
@@ -1,1 +1,1 @@
-export { jsonFileAliases, findOrCreateAliasesFile } from "./utils";
+export { jsonFileAliases, findOrCreateAliasesFile } from "./utils.js";


### PR DESCRIPTION
## Summary

The `node-helpers` package was exporting things from `"./utils"`, but this should have been `"./utils.js"`. This impacted the CLI since it uses the helpers, so no commands would work. Also includes some dependabot dep bumps; closes #56, #71, #72. 

## Details

Prior to the fix, you would run into this error when trying to actually use `jsonFileAliases` from `node-helpers` as well as any CLI commands:
```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/Users/dtb/tbl/tableland-js/packages/node-helpers/dist/esm/utils' imported from /Users/dtb/tbl/tableland-js/packages/node-helpers/dist/esm/index.js
```

The changes bump the `cli` to 5.3.2 and `node-helpers` to 0.0.2.

## How it was tested

- Built the CLI and tested the `dist/cli.js` commands locally.
- Symlink in a test Node.js project to import/use `jsonFileAliase` from `@tableland/node-helpers`.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
