### PR TITLE
Enable usage with Node.js 20 LTS version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        nodejs: [16, 18]
+        nodejs: [16, 18, 20]
 
     steps:
       - name: Checkout 🛎️

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,17 +9,27 @@
         "packages/*"
       ],
       "devDependencies": {
+        "@databases/escape-identifier": "^1.0.3",
+        "@databases/sql": "^3.2.0",
+        "@ethersproject/experimental": "^5.7.0",
+        "@playwright/test": "^1.30.0",
         "@types/chai": "^4.3.5",
         "@types/chai-as-promised": "^7.1.5",
+        "@types/cosmiconfig": "^6.0.0",
         "@types/cross-spawn": "^6.0.2",
         "@types/inquirer": "^9.0.3",
+        "@types/js-yaml": "^4.0.5",
         "@types/mocha": "^10.0.1",
         "@types/shelljs": "^0.8.12",
+        "@types/sinon": "^10.0.20",
+        "@types/yargs": "^17.0.19",
         "@typescript-eslint/eslint-plugin": "^5.62.0",
         "@typescript-eslint/parser": "^5.62.0",
         "c8": "^8.0.1",
         "chai": "^4.3.7",
         "chai-as-promised": "^7.1.1",
+        "d1-orm": "^0.9.0",
+        "drizzle-orm": "^0.29.0",
         "eslint": "^8.32.0",
         "eslint-config-prettier": "^8.5.0",
         "eslint-config-standard": "^17.0.0",
@@ -31,9 +41,14 @@
         "eslint-plugin-promise": "^6.1.1",
         "lerna": "^7.1.1",
         "mocha": "^10.2.0",
+        "mock-stdin": "^1.0.0",
+        "openapi-typescript": "6.2.4",
         "prettier": "^3.0.0",
         "prettier-plugin-solidity": "^1.1.3",
-        "ts-node": "^10.9.1"
+        "sinon": "^17.0.1",
+        "tempy": "^3.0.0",
+        "ts-node": "^10.9.1",
+        "typedoc": "^0.25.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -9455,6 +9470,53 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/openapi-typescript": {
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/openapi-typescript/-/openapi-typescript-6.2.4.tgz",
+      "integrity": "sha512-P/VK7oJ3TnIS67o1UzuS1pMnry4mzNzeQG0ZjLdPGT04mN9FeeTgHw1bN6MiANFN0tO6BcRavSL5tUFAh6iiwg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-colors": "^4.1.3",
+        "fast-glob": "^3.2.12",
+        "js-yaml": "^4.1.0",
+        "supports-color": "^9.3.1",
+        "undici": "^5.22.0",
+        "yargs-parser": "^21.1.1"
+      },
+      "bin": {
+        "openapi-typescript": "bin/cli.js"
+      }
+    },
+    "node_modules/openapi-typescript/node_modules/ansi-colors": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/openapi-typescript/node_modules/supports-color": {
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-9.4.0.tgz",
+      "integrity": "sha512-VL+lNrEoIXww1coLPOmiEmK/0sGigko5COxI09KzHc2VJXJsQ37UaQ+8quuxjDeA7+KnLGTWRyOXSLLR2Wb4jw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/openapi-typescript/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz",
@@ -12730,15 +12792,6 @@
       },
       "bin": {
         "tableland": "dist/cli.js"
-      },
-      "devDependencies": {
-        "@types/cosmiconfig": "^6.0.0",
-        "@types/js-yaml": "^4.0.5",
-        "@types/sinon": "^10.0.20",
-        "@types/yargs": "^17.0.19",
-        "mock-stdin": "^1.0.0",
-        "sinon": "^17.0.1",
-        "tempy": "^3.0.0"
       }
     },
     "packages/cli/node_modules/ansi-escapes": {
@@ -12953,7 +13006,7 @@
     },
     "packages/local": {
       "name": "@tableland/local",
-      "version": "2.2.0",
+      "version": "3.0.0",
       "hasInstallScript": true,
       "license": "MIT AND Apache-2.0",
       "dependencies": {
@@ -13028,63 +13081,6 @@
         "@tableland/evm": "^4.5.0",
         "@tableland/sqlparser": "^1.3.0",
         "ethers": "^5.7.2"
-      },
-      "devDependencies": {
-        "@databases/escape-identifier": "^1.0.3",
-        "@databases/sql": "^3.2.0",
-        "@ethersproject/experimental": "^5.7.0",
-        "@playwright/test": "^1.30.0",
-        "d1-orm": "^0.9.0",
-        "drizzle-orm": "^0.29.0",
-        "openapi-typescript": "6.2.4",
-        "typedoc": "^0.25.0"
-      }
-    },
-    "packages/sdk/node_modules/ansi-colors": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
-      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "packages/sdk/node_modules/openapi-typescript": {
-      "version": "6.2.4",
-      "resolved": "https://registry.npmjs.org/openapi-typescript/-/openapi-typescript-6.2.4.tgz",
-      "integrity": "sha512-P/VK7oJ3TnIS67o1UzuS1pMnry4mzNzeQG0ZjLdPGT04mN9FeeTgHw1bN6MiANFN0tO6BcRavSL5tUFAh6iiwg==",
-      "dev": true,
-      "dependencies": {
-        "ansi-colors": "^4.1.3",
-        "fast-glob": "^3.2.12",
-        "js-yaml": "^4.1.0",
-        "supports-color": "^9.3.1",
-        "undici": "^5.22.0",
-        "yargs-parser": "^21.1.1"
-      },
-      "bin": {
-        "openapi-typescript": "bin/cli.js"
-      }
-    },
-    "packages/sdk/node_modules/supports-color": {
-      "version": "9.4.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-9.4.0.tgz",
-      "integrity": "sha512-VL+lNrEoIXww1coLPOmiEmK/0sGigko5COxI09KzHc2VJXJsQ37UaQ+8quuxjDeA7+KnLGTWRyOXSLLR2Wb4jw==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
-    "packages/sdk/node_modules/yargs-parser": {
-      "version": "21.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
       }
     }
   },
@@ -14514,10 +14510,6 @@
         "@tableland/node-helpers": "^0.0.2",
         "@tableland/sdk": "^5.1.0",
         "@tableland/sqlparser": "^1.3.0",
-        "@types/cosmiconfig": "^6.0.0",
-        "@types/js-yaml": "^4.0.5",
-        "@types/sinon": "^10.0.20",
-        "@types/yargs": "^17.0.19",
         "cli-select-2": "^2.0.0",
         "cosmiconfig": "^8.0.0",
         "data-uri-to-buffer": "^6.0.1",
@@ -14525,12 +14517,9 @@
         "ethers": "^5.7.1",
         "inquirer": "^9.1.2",
         "js-yaml": "^4.1.0",
-        "mock-stdin": "^1.0.0",
         "node-fetch": "^3.2.10",
         "readline": "^1.3.0",
-        "sinon": "^17.0.1",
         "table": "^6.8.1",
-        "tempy": "^3.0.0",
         "yargs": "^17.6.2"
       },
       "dependencies": {
@@ -14707,51 +14696,9 @@
       "version": "file:packages/sdk",
       "requires": {
         "@async-generators/from-emitter": "^0.3.0",
-        "@databases/escape-identifier": "^1.0.3",
-        "@databases/sql": "^3.2.0",
-        "@ethersproject/experimental": "^5.7.0",
-        "@playwright/test": "^1.30.0",
         "@tableland/evm": "^4.5.0",
         "@tableland/sqlparser": "^1.3.0",
-        "d1-orm": "^0.9.0",
-        "drizzle-orm": "^0.29.0",
-        "ethers": "^5.7.2",
-        "openapi-typescript": "6.2.4",
-        "typedoc": "^0.25.0"
-      },
-      "dependencies": {
-        "ansi-colors": {
-          "version": "4.1.3",
-          "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
-          "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
-          "dev": true
-        },
-        "openapi-typescript": {
-          "version": "6.2.4",
-          "resolved": "https://registry.npmjs.org/openapi-typescript/-/openapi-typescript-6.2.4.tgz",
-          "integrity": "sha512-P/VK7oJ3TnIS67o1UzuS1pMnry4mzNzeQG0ZjLdPGT04mN9FeeTgHw1bN6MiANFN0tO6BcRavSL5tUFAh6iiwg==",
-          "dev": true,
-          "requires": {
-            "ansi-colors": "^4.1.3",
-            "fast-glob": "^3.2.12",
-            "js-yaml": "^4.1.0",
-            "supports-color": "^9.3.1",
-            "undici": "^5.22.0",
-            "yargs-parser": "^21.1.1"
-          }
-        },
-        "supports-color": {
-          "version": "9.4.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-9.4.0.tgz",
-          "integrity": "sha512-VL+lNrEoIXww1coLPOmiEmK/0sGigko5COxI09KzHc2VJXJsQ37UaQ+8quuxjDeA7+KnLGTWRyOXSLLR2Wb4jw==",
-          "dev": true
-        },
-        "yargs-parser": {
-          "version": "21.1.1",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-          "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-          "dev": true
-        }
+        "ethers": "^5.7.2"
       }
     },
     "@tableland/sqlparser": {
@@ -20187,6 +20134,40 @@
         "define-lazy-prop": "^2.0.0",
         "is-docker": "^2.1.1",
         "is-wsl": "^2.2.0"
+      }
+    },
+    "openapi-typescript": {
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/openapi-typescript/-/openapi-typescript-6.2.4.tgz",
+      "integrity": "sha512-P/VK7oJ3TnIS67o1UzuS1pMnry4mzNzeQG0ZjLdPGT04mN9FeeTgHw1bN6MiANFN0tO6BcRavSL5tUFAh6iiwg==",
+      "dev": true,
+      "requires": {
+        "ansi-colors": "^4.1.3",
+        "fast-glob": "^3.2.12",
+        "js-yaml": "^4.1.0",
+        "supports-color": "^9.3.1",
+        "undici": "^5.22.0",
+        "yargs-parser": "^21.1.1"
+      },
+      "dependencies": {
+        "ansi-colors": {
+          "version": "4.1.3",
+          "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+          "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "9.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-9.4.0.tgz",
+          "integrity": "sha512-VL+lNrEoIXww1coLPOmiEmK/0sGigko5COxI09KzHc2VJXJsQ37UaQ+8quuxjDeA7+KnLGTWRyOXSLLR2Wb4jw==",
+          "dev": true
+        },
+        "yargs-parser": {
+          "version": "21.1.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+          "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+          "dev": true
+        }
       }
     },
     "optionator": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13006,7 +13006,7 @@
     },
     "packages/local": {
       "name": "@tableland/local",
-      "version": "3.0.0",
+      "version": "2.3.0",
       "hasInstallScript": true,
       "license": "MIT AND Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -14,17 +14,27 @@
     "build": "npx lerna run build"
   },
   "devDependencies": {
+    "@databases/escape-identifier": "^1.0.3",
+    "@databases/sql": "^3.2.0",
+    "@ethersproject/experimental": "^5.7.0",
+    "@playwright/test": "^1.30.0",
     "@types/chai": "^4.3.5",
     "@types/chai-as-promised": "^7.1.5",
+    "@types/cosmiconfig": "^6.0.0",
     "@types/cross-spawn": "^6.0.2",
     "@types/inquirer": "^9.0.3",
+    "@types/js-yaml": "^4.0.5",
     "@types/mocha": "^10.0.1",
     "@types/shelljs": "^0.8.12",
+    "@types/sinon": "^10.0.20",
+    "@types/yargs": "^17.0.19",
     "@typescript-eslint/eslint-plugin": "^5.62.0",
     "@typescript-eslint/parser": "^5.62.0",
     "c8": "^8.0.1",
     "chai": "^4.3.7",
     "chai-as-promised": "^7.1.1",
+    "d1-orm": "^0.9.0",
+    "drizzle-orm": "^0.29.0",
     "eslint": "^8.32.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-config-standard": "^17.0.0",
@@ -35,9 +45,14 @@
     "eslint-plugin-prettier": "^5.0.0",
     "eslint-plugin-promise": "^6.1.1",
     "lerna": "^7.1.1",
+    "mock-stdin": "^1.0.0",
     "mocha": "^10.2.0",
+    "openapi-typescript": "6.2.4",
     "prettier": "^3.0.0",
     "prettier-plugin-solidity": "^1.1.3",
-    "ts-node": "^10.9.1"
+    "sinon": "^17.0.1",
+    "tempy": "^3.0.0",
+    "ts-node": "^10.9.1",
+    "typedoc": "^0.25.0"
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -43,15 +43,6 @@
     "tableland": "node ./dist/cli.js"
   },
   "license": "MIT AND Apache-2.0",
-  "devDependencies": {
-    "@types/cosmiconfig": "^6.0.0",
-    "@types/js-yaml": "^4.0.5",
-    "@types/sinon": "^10.0.20",
-    "@types/yargs": "^17.0.19",
-    "mock-stdin": "^1.0.0",
-    "sinon": "^17.0.1",
-    "tempy": "^3.0.0"
-  },
   "dependencies": {
     "@ensdomains/ensjs": "3.0.0-alpha.64",
     "@tableland/node-helpers": "^0.0.2",

--- a/packages/cli/src/commands/read.ts
+++ b/packages/cli/src/commands/read.ts
@@ -101,7 +101,7 @@ export const handler = async (argv: Arguments<Options>): Promise<void> => {
           unwrap: argv.unwrap,
         });
       } catch (err: any) {
-        if (err.message.includes("in JSON at position") as boolean) {
+        if (err.message.includes("JSON at position") as boolean) {
           logger.error("Can't unwrap multiple rows. Use --unwrap=false");
           /* c8 ignore next 3 */
         } else {

--- a/packages/local/package.json
+++ b/packages/local/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tableland/local",
-  "version": "3.0.0",
+  "version": "2.3.0",
   "description": "Tooling to start a sandboxed Tableland network.",
   "repository": "https://github.com/tablelandnetwork/tableland-js",
   "license": "MIT AND Apache-2.0",

--- a/packages/local/package.json
+++ b/packages/local/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tableland/local",
-  "version": "2.2.0",
+  "version": "3.0.0",
   "description": "Tooling to start a sandboxed Tableland network.",
   "repository": "https://github.com/tablelandnetwork/tableland-js",
   "license": "MIT AND Apache-2.0",

--- a/packages/local/registry/package-lock.json
+++ b/packages/local/registry/package-lock.json
@@ -12,7 +12,7 @@
         "@openzeppelin/hardhat-upgrades": "^1.21.0",
         "@tableland/evm": "^4.5.0",
         "erc721a-upgradeable": "^4.2.2",
-        "hardhat": "^2.14.0"
+        "hardhat": "^2.19.0"
       }
     },
     "node_modules/@chainsafe/as-sha256": {
@@ -878,15 +878,15 @@
       }
     },
     "node_modules/@nomicfoundation/ethereumjs-block": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-block/-/ethereumjs-block-5.0.1.tgz",
-      "integrity": "sha512-u1Yioemi6Ckj3xspygu/SfFvm8vZEO8/Yx5a1QLzi6nVU0jz3Pg2OmHKJ5w+D9Ogk1vhwRiqEBAqcb0GVhCyHw==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-block/-/ethereumjs-block-5.0.2.tgz",
+      "integrity": "sha512-hSe6CuHI4SsSiWWjHDIzWhSiAVpzMUcDRpWYzN0T9l8/Rz7xNn3elwVOJ/tAyS0LqL6vitUD78Uk7lQDXZun7Q==",
       "dependencies": {
-        "@nomicfoundation/ethereumjs-common": "4.0.1",
-        "@nomicfoundation/ethereumjs-rlp": "5.0.1",
-        "@nomicfoundation/ethereumjs-trie": "6.0.1",
-        "@nomicfoundation/ethereumjs-tx": "5.0.1",
-        "@nomicfoundation/ethereumjs-util": "9.0.1",
+        "@nomicfoundation/ethereumjs-common": "4.0.2",
+        "@nomicfoundation/ethereumjs-rlp": "5.0.2",
+        "@nomicfoundation/ethereumjs-trie": "6.0.2",
+        "@nomicfoundation/ethereumjs-tx": "5.0.2",
+        "@nomicfoundation/ethereumjs-util": "9.0.2",
         "ethereum-cryptography": "0.1.3",
         "ethers": "^5.7.1"
       },
@@ -895,17 +895,17 @@
       }
     },
     "node_modules/@nomicfoundation/ethereumjs-blockchain": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-blockchain/-/ethereumjs-blockchain-7.0.1.tgz",
-      "integrity": "sha512-NhzndlGg829XXbqJEYrF1VeZhAwSPgsK/OB7TVrdzft3y918hW5KNd7gIZ85sn6peDZOdjBsAXIpXZ38oBYE5A==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-blockchain/-/ethereumjs-blockchain-7.0.2.tgz",
+      "integrity": "sha512-8UUsSXJs+MFfIIAKdh3cG16iNmWzWC/91P40sazNvrqhhdR/RtGDlFk2iFTGbBAZPs2+klZVzhRX8m2wvuvz3w==",
       "dependencies": {
-        "@nomicfoundation/ethereumjs-block": "5.0.1",
-        "@nomicfoundation/ethereumjs-common": "4.0.1",
-        "@nomicfoundation/ethereumjs-ethash": "3.0.1",
-        "@nomicfoundation/ethereumjs-rlp": "5.0.1",
-        "@nomicfoundation/ethereumjs-trie": "6.0.1",
-        "@nomicfoundation/ethereumjs-tx": "5.0.1",
-        "@nomicfoundation/ethereumjs-util": "9.0.1",
+        "@nomicfoundation/ethereumjs-block": "5.0.2",
+        "@nomicfoundation/ethereumjs-common": "4.0.2",
+        "@nomicfoundation/ethereumjs-ethash": "3.0.2",
+        "@nomicfoundation/ethereumjs-rlp": "5.0.2",
+        "@nomicfoundation/ethereumjs-trie": "6.0.2",
+        "@nomicfoundation/ethereumjs-tx": "5.0.2",
+        "@nomicfoundation/ethereumjs-util": "9.0.2",
         "abstract-level": "^1.0.3",
         "debug": "^4.3.3",
         "ethereum-cryptography": "0.1.3",
@@ -918,22 +918,22 @@
       }
     },
     "node_modules/@nomicfoundation/ethereumjs-common": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-common/-/ethereumjs-common-4.0.1.tgz",
-      "integrity": "sha512-OBErlkfp54GpeiE06brBW/TTbtbuBJV5YI5Nz/aB2evTDo+KawyEzPjBlSr84z/8MFfj8wS2wxzQX1o32cev5g==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-common/-/ethereumjs-common-4.0.2.tgz",
+      "integrity": "sha512-I2WGP3HMGsOoycSdOTSqIaES0ughQTueOsddJ36aYVpI3SN8YSusgRFLwzDJwRFVIYDKx/iJz0sQ5kBHVgdDwg==",
       "dependencies": {
-        "@nomicfoundation/ethereumjs-util": "9.0.1",
+        "@nomicfoundation/ethereumjs-util": "9.0.2",
         "crc-32": "^1.2.0"
       }
     },
     "node_modules/@nomicfoundation/ethereumjs-ethash": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-ethash/-/ethereumjs-ethash-3.0.1.tgz",
-      "integrity": "sha512-KDjGIB5igzWOp8Ik5I6QiRH5DH+XgILlplsHR7TEuWANZA759G6krQ6o8bvj+tRUz08YygMQu/sGd9mJ1DYT8w==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-ethash/-/ethereumjs-ethash-3.0.2.tgz",
+      "integrity": "sha512-8PfoOQCcIcO9Pylq0Buijuq/O73tmMVURK0OqdjhwqcGHYC2PwhbajDh7GZ55ekB0Px197ajK3PQhpKoiI/UPg==",
       "dependencies": {
-        "@nomicfoundation/ethereumjs-block": "5.0.1",
-        "@nomicfoundation/ethereumjs-rlp": "5.0.1",
-        "@nomicfoundation/ethereumjs-util": "9.0.1",
+        "@nomicfoundation/ethereumjs-block": "5.0.2",
+        "@nomicfoundation/ethereumjs-rlp": "5.0.2",
+        "@nomicfoundation/ethereumjs-util": "9.0.2",
         "abstract-level": "^1.0.3",
         "bigint-crypto-utils": "^3.0.23",
         "ethereum-cryptography": "0.1.3"
@@ -943,14 +943,14 @@
       }
     },
     "node_modules/@nomicfoundation/ethereumjs-evm": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-evm/-/ethereumjs-evm-2.0.1.tgz",
-      "integrity": "sha512-oL8vJcnk0Bx/onl+TgQOQ1t/534GKFaEG17fZmwtPFeH8S5soiBYPCLUrvANOl4sCp9elYxIMzIiTtMtNNN8EQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-evm/-/ethereumjs-evm-2.0.2.tgz",
+      "integrity": "sha512-rBLcUaUfANJxyOx9HIdMX6uXGin6lANCulIm/pjMgRqfiCRMZie3WKYxTSd8ZE/d+qT+zTedBF4+VHTdTSePmQ==",
       "dependencies": {
         "@ethersproject/providers": "^5.7.1",
-        "@nomicfoundation/ethereumjs-common": "4.0.1",
-        "@nomicfoundation/ethereumjs-tx": "5.0.1",
-        "@nomicfoundation/ethereumjs-util": "9.0.1",
+        "@nomicfoundation/ethereumjs-common": "4.0.2",
+        "@nomicfoundation/ethereumjs-tx": "5.0.2",
+        "@nomicfoundation/ethereumjs-util": "9.0.2",
         "debug": "^4.3.3",
         "ethereum-cryptography": "0.1.3",
         "mcl-wasm": "^0.7.1",
@@ -961,9 +961,9 @@
       }
     },
     "node_modules/@nomicfoundation/ethereumjs-rlp": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-rlp/-/ethereumjs-rlp-5.0.1.tgz",
-      "integrity": "sha512-xtxrMGa8kP4zF5ApBQBtjlSbN5E2HI8m8FYgVSYAnO6ssUoY5pVPGy2H8+xdf/bmMa22Ce8nWMH3aEW8CcqMeQ==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-rlp/-/ethereumjs-rlp-5.0.2.tgz",
+      "integrity": "sha512-QwmemBc+MMsHJ1P1QvPl8R8p2aPvvVcKBbvHnQOKBpBztEo0omN0eaob6FeZS/e3y9NSe+mfu3nNFBHszqkjTA==",
       "bin": {
         "rlp": "bin/rlp"
       },
@@ -972,12 +972,12 @@
       }
     },
     "node_modules/@nomicfoundation/ethereumjs-statemanager": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-statemanager/-/ethereumjs-statemanager-2.0.1.tgz",
-      "integrity": "sha512-B5ApMOnlruVOR7gisBaYwFX+L/AP7i/2oAahatssjPIBVDF6wTX1K7Qpa39E/nzsH8iYuL3krkYeUFIdO3EMUQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-statemanager/-/ethereumjs-statemanager-2.0.2.tgz",
+      "integrity": "sha512-dlKy5dIXLuDubx8Z74sipciZnJTRSV/uHG48RSijhgm1V7eXYFC567xgKtsKiVZB1ViTP9iFL4B6Je0xD6X2OA==",
       "dependencies": {
-        "@nomicfoundation/ethereumjs-common": "4.0.1",
-        "@nomicfoundation/ethereumjs-rlp": "5.0.1",
+        "@nomicfoundation/ethereumjs-common": "4.0.2",
+        "@nomicfoundation/ethereumjs-rlp": "5.0.2",
         "debug": "^4.3.3",
         "ethereum-cryptography": "0.1.3",
         "ethers": "^5.7.1",
@@ -985,12 +985,12 @@
       }
     },
     "node_modules/@nomicfoundation/ethereumjs-trie": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-trie/-/ethereumjs-trie-6.0.1.tgz",
-      "integrity": "sha512-A64It/IMpDVODzCgxDgAAla8jNjNtsoQZIzZUfIV5AY6Coi4nvn7+VReBn5itlxMiL2yaTlQr9TRWp3CSI6VoA==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-trie/-/ethereumjs-trie-6.0.2.tgz",
+      "integrity": "sha512-yw8vg9hBeLYk4YNg5MrSJ5H55TLOv2FSWUTROtDtTMMmDGROsAu+0tBjiNGTnKRi400M6cEzoFfa89Fc5k8NTQ==",
       "dependencies": {
-        "@nomicfoundation/ethereumjs-rlp": "5.0.1",
-        "@nomicfoundation/ethereumjs-util": "9.0.1",
+        "@nomicfoundation/ethereumjs-rlp": "5.0.2",
+        "@nomicfoundation/ethereumjs-util": "9.0.2",
         "@types/readable-stream": "^2.3.13",
         "ethereum-cryptography": "0.1.3",
         "readable-stream": "^3.6.0"
@@ -1000,15 +1000,15 @@
       }
     },
     "node_modules/@nomicfoundation/ethereumjs-tx": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-tx/-/ethereumjs-tx-5.0.1.tgz",
-      "integrity": "sha512-0HwxUF2u2hrsIM1fsasjXvlbDOq1ZHFV2dd1yGq8CA+MEYhaxZr8OTScpVkkxqMwBcc5y83FyPl0J9MZn3kY0w==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-tx/-/ethereumjs-tx-5.0.2.tgz",
+      "integrity": "sha512-T+l4/MmTp7VhJeNloMkM+lPU3YMUaXdcXgTGCf8+ZFvV9NYZTRLFekRwlG6/JMmVfIfbrW+dRRJ9A6H5Q/Z64g==",
       "dependencies": {
         "@chainsafe/ssz": "^0.9.2",
         "@ethersproject/providers": "^5.7.2",
-        "@nomicfoundation/ethereumjs-common": "4.0.1",
-        "@nomicfoundation/ethereumjs-rlp": "5.0.1",
-        "@nomicfoundation/ethereumjs-util": "9.0.1",
+        "@nomicfoundation/ethereumjs-common": "4.0.2",
+        "@nomicfoundation/ethereumjs-rlp": "5.0.2",
+        "@nomicfoundation/ethereumjs-util": "9.0.2",
         "ethereum-cryptography": "0.1.3"
       },
       "engines": {
@@ -1053,12 +1053,12 @@
       }
     },
     "node_modules/@nomicfoundation/ethereumjs-util": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-util/-/ethereumjs-util-9.0.1.tgz",
-      "integrity": "sha512-TwbhOWQ8QoSCFhV/DDfSmyfFIHjPjFBj957219+V3jTZYZ2rf9PmDtNOeZWAE3p3vlp8xb02XGpd0v6nTUPbsA==",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-util/-/ethereumjs-util-9.0.2.tgz",
+      "integrity": "sha512-4Wu9D3LykbSBWZo8nJCnzVIYGvGCuyiYLIJa9XXNVt1q1jUzHdB+sJvx95VGCpPkCT+IbLecW6yfzy3E1bQrwQ==",
       "dependencies": {
         "@chainsafe/ssz": "^0.10.0",
-        "@nomicfoundation/ethereumjs-rlp": "5.0.1",
+        "@nomicfoundation/ethereumjs-rlp": "5.0.2",
         "ethereum-cryptography": "0.1.3"
       },
       "engines": {
@@ -1083,19 +1083,19 @@
       }
     },
     "node_modules/@nomicfoundation/ethereumjs-vm": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-vm/-/ethereumjs-vm-7.0.1.tgz",
-      "integrity": "sha512-rArhyn0jPsS/D+ApFsz3yVJMQ29+pVzNZ0VJgkzAZ+7FqXSRtThl1C1prhmlVr3YNUlfpZ69Ak+RUT4g7VoOuQ==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-vm/-/ethereumjs-vm-7.0.2.tgz",
+      "integrity": "sha512-Bj3KZT64j54Tcwr7Qm/0jkeZXJMfdcAtRBedou+Hx0dPOSIgqaIr0vvLwP65TpHbak2DmAq+KJbW2KNtIoFwvA==",
       "dependencies": {
-        "@nomicfoundation/ethereumjs-block": "5.0.1",
-        "@nomicfoundation/ethereumjs-blockchain": "7.0.1",
-        "@nomicfoundation/ethereumjs-common": "4.0.1",
-        "@nomicfoundation/ethereumjs-evm": "2.0.1",
-        "@nomicfoundation/ethereumjs-rlp": "5.0.1",
-        "@nomicfoundation/ethereumjs-statemanager": "2.0.1",
-        "@nomicfoundation/ethereumjs-trie": "6.0.1",
-        "@nomicfoundation/ethereumjs-tx": "5.0.1",
-        "@nomicfoundation/ethereumjs-util": "9.0.1",
+        "@nomicfoundation/ethereumjs-block": "5.0.2",
+        "@nomicfoundation/ethereumjs-blockchain": "7.0.2",
+        "@nomicfoundation/ethereumjs-common": "4.0.2",
+        "@nomicfoundation/ethereumjs-evm": "2.0.2",
+        "@nomicfoundation/ethereumjs-rlp": "5.0.2",
+        "@nomicfoundation/ethereumjs-statemanager": "2.0.2",
+        "@nomicfoundation/ethereumjs-trie": "6.0.2",
+        "@nomicfoundation/ethereumjs-tx": "5.0.2",
+        "@nomicfoundation/ethereumjs-util": "9.0.2",
         "debug": "^4.3.3",
         "ethereum-cryptography": "0.1.3",
         "mcl-wasm": "^0.7.1",
@@ -1936,17 +1936,6 @@
       "integrity": "sha512-LEyx4aLEC3x6T0UguF6YILf+ntvmOaWsVfENmIW0E9H09vKlLDGelMjjSm0jkDHALj8A8quZ/HapKNigzwge+Q==",
       "peer": true
     },
-    "node_modules/abort-controller": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "dependencies": {
-        "event-target-shim": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=6.5"
-      }
-    },
     "node_modules/abstract-level": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/abstract-level/-/abstract-level-1.0.3.tgz",
@@ -2329,9 +2318,9 @@
       "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="
     },
     "node_modules/bigint-crypto-utils": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/bigint-crypto-utils/-/bigint-crypto-utils-3.2.2.tgz",
-      "integrity": "sha512-U1RbE3aX9ayCUVcIPHuPDPKcK3SFOXf93J1UK/iHlJuQB7bhagPIX06/CLpLEsDThJ7KA4Dhrnzynl+d2weTiw==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/bigint-crypto-utils/-/bigint-crypto-utils-3.3.0.tgz",
+      "integrity": "sha512-jOTSb+drvEDxEq6OuUybOAv/xxoh3cuYRUIPyu8sSHQNKM303UQ2R1DAo45o1AkcIXw6fzbaFI1+xGGdaXs2lg==",
       "engines": {
         "node": ">=14.0.0"
       }
@@ -2491,6 +2480,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
       "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "peer": true,
       "dependencies": {
         "function-bind": "^1.1.1",
         "get-intrinsic": "^1.0.2"
@@ -4088,14 +4078,6 @@
         "npm": ">=3"
       }
     },
-    "node_modules/event-target-shim": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/evp_bytestokey": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
@@ -4301,7 +4283,8 @@
     "node_modules/function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "peer": true
     },
     "node_modules/function.prototype.name": {
       "version": "1.1.5",
@@ -4356,6 +4339,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.0.tgz",
       "integrity": "sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==",
+      "peer": true,
       "dependencies": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
@@ -4582,27 +4566,26 @@
       }
     },
     "node_modules/hardhat": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/hardhat/-/hardhat-2.14.0.tgz",
-      "integrity": "sha512-73jsInY4zZahMSVFurSK+5TNCJTXMv+vemvGia0Ac34Mm19fYp6vEPVGF3sucbumszsYxiTT2TbS8Ii2dsDSoQ==",
+      "version": "2.19.1",
+      "resolved": "https://registry.npmjs.org/hardhat/-/hardhat-2.19.1.tgz",
+      "integrity": "sha512-bsWa63g1GB78ZyMN08WLhFElLPA+J+pShuKD1BFO2+88g3l+BL3R07vj9deIi9dMbssxgE714Gof1dBEDGqnCw==",
       "dependencies": {
         "@ethersproject/abi": "^5.1.2",
         "@metamask/eth-sig-util": "^4.0.0",
-        "@nomicfoundation/ethereumjs-block": "5.0.1",
-        "@nomicfoundation/ethereumjs-blockchain": "7.0.1",
-        "@nomicfoundation/ethereumjs-common": "4.0.1",
-        "@nomicfoundation/ethereumjs-evm": "2.0.1",
-        "@nomicfoundation/ethereumjs-rlp": "5.0.1",
-        "@nomicfoundation/ethereumjs-statemanager": "2.0.1",
-        "@nomicfoundation/ethereumjs-trie": "6.0.1",
-        "@nomicfoundation/ethereumjs-tx": "5.0.1",
-        "@nomicfoundation/ethereumjs-util": "9.0.1",
-        "@nomicfoundation/ethereumjs-vm": "7.0.1",
+        "@nomicfoundation/ethereumjs-block": "5.0.2",
+        "@nomicfoundation/ethereumjs-blockchain": "7.0.2",
+        "@nomicfoundation/ethereumjs-common": "4.0.2",
+        "@nomicfoundation/ethereumjs-evm": "2.0.2",
+        "@nomicfoundation/ethereumjs-rlp": "5.0.2",
+        "@nomicfoundation/ethereumjs-statemanager": "2.0.2",
+        "@nomicfoundation/ethereumjs-trie": "6.0.2",
+        "@nomicfoundation/ethereumjs-tx": "5.0.2",
+        "@nomicfoundation/ethereumjs-util": "9.0.2",
+        "@nomicfoundation/ethereumjs-vm": "7.0.2",
         "@nomicfoundation/solidity-analyzer": "^0.1.0",
         "@sentry/node": "^5.18.1",
         "@types/bn.js": "^5.1.0",
         "@types/lru-cache": "^5.1.0",
-        "abort-controller": "^3.0.0",
         "adm-zip": "^0.4.16",
         "aggregate-error": "^3.0.0",
         "ansi-escapes": "^4.3.0",
@@ -4625,7 +4608,6 @@
         "mnemonist": "^0.38.0",
         "mocha": "^10.0.0",
         "p-map": "^4.0.0",
-        "qs": "^6.7.0",
         "raw-body": "^2.4.1",
         "resolve": "1.17.0",
         "semver": "^6.3.0",
@@ -4639,9 +4621,6 @@
       },
       "bin": {
         "hardhat": "internal/cli/bootstrap.js"
-      },
-      "engines": {
-        "node": ">=14.0.0"
       },
       "peerDependencies": {
         "ts-node": "*",
@@ -4685,6 +4664,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "peer": true,
       "dependencies": {
         "function-bind": "^1.1.1"
       },
@@ -4737,6 +4717,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
       "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -5287,9 +5268,9 @@
       "peer": true
     },
     "node_modules/js-sdsl": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.4.0.tgz",
-      "integrity": "sha512-FfVSdx6pJ41Oa+CF7RDaFmTnCaFhua+SNYQX74riGOpl96x+2jQCqEfQ2bnXu/5DPCqlRuiqyvTJM0Qjz26IVg==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.4.2.tgz",
+      "integrity": "sha512-dwXFwByc/ajSV6m5bcKAPwe4yDDF6D614pxmIi5odytzxRlwqF6nwoiCek80Ixc7Cvma5awClxrzFtxCQvcM8w==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/js-sdsl"
@@ -6040,6 +6021,7 @@
       "version": "1.12.3",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
       "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -6329,6 +6311,7 @@
       "version": "6.11.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
       "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
+      "peer": true,
       "dependencies": {
         "side-channel": "^1.0.4"
       },
@@ -6965,6 +6948,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
       "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "peer": true,
       "dependencies": {
         "call-bind": "^1.0.0",
         "get-intrinsic": "^1.0.2",
@@ -9350,31 +9334,31 @@
       }
     },
     "@nomicfoundation/ethereumjs-block": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-block/-/ethereumjs-block-5.0.1.tgz",
-      "integrity": "sha512-u1Yioemi6Ckj3xspygu/SfFvm8vZEO8/Yx5a1QLzi6nVU0jz3Pg2OmHKJ5w+D9Ogk1vhwRiqEBAqcb0GVhCyHw==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-block/-/ethereumjs-block-5.0.2.tgz",
+      "integrity": "sha512-hSe6CuHI4SsSiWWjHDIzWhSiAVpzMUcDRpWYzN0T9l8/Rz7xNn3elwVOJ/tAyS0LqL6vitUD78Uk7lQDXZun7Q==",
       "requires": {
-        "@nomicfoundation/ethereumjs-common": "4.0.1",
-        "@nomicfoundation/ethereumjs-rlp": "5.0.1",
-        "@nomicfoundation/ethereumjs-trie": "6.0.1",
-        "@nomicfoundation/ethereumjs-tx": "5.0.1",
-        "@nomicfoundation/ethereumjs-util": "9.0.1",
+        "@nomicfoundation/ethereumjs-common": "4.0.2",
+        "@nomicfoundation/ethereumjs-rlp": "5.0.2",
+        "@nomicfoundation/ethereumjs-trie": "6.0.2",
+        "@nomicfoundation/ethereumjs-tx": "5.0.2",
+        "@nomicfoundation/ethereumjs-util": "9.0.2",
         "ethereum-cryptography": "0.1.3",
         "ethers": "^5.7.1"
       }
     },
     "@nomicfoundation/ethereumjs-blockchain": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-blockchain/-/ethereumjs-blockchain-7.0.1.tgz",
-      "integrity": "sha512-NhzndlGg829XXbqJEYrF1VeZhAwSPgsK/OB7TVrdzft3y918hW5KNd7gIZ85sn6peDZOdjBsAXIpXZ38oBYE5A==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-blockchain/-/ethereumjs-blockchain-7.0.2.tgz",
+      "integrity": "sha512-8UUsSXJs+MFfIIAKdh3cG16iNmWzWC/91P40sazNvrqhhdR/RtGDlFk2iFTGbBAZPs2+klZVzhRX8m2wvuvz3w==",
       "requires": {
-        "@nomicfoundation/ethereumjs-block": "5.0.1",
-        "@nomicfoundation/ethereumjs-common": "4.0.1",
-        "@nomicfoundation/ethereumjs-ethash": "3.0.1",
-        "@nomicfoundation/ethereumjs-rlp": "5.0.1",
-        "@nomicfoundation/ethereumjs-trie": "6.0.1",
-        "@nomicfoundation/ethereumjs-tx": "5.0.1",
-        "@nomicfoundation/ethereumjs-util": "9.0.1",
+        "@nomicfoundation/ethereumjs-block": "5.0.2",
+        "@nomicfoundation/ethereumjs-common": "4.0.2",
+        "@nomicfoundation/ethereumjs-ethash": "3.0.2",
+        "@nomicfoundation/ethereumjs-rlp": "5.0.2",
+        "@nomicfoundation/ethereumjs-trie": "6.0.2",
+        "@nomicfoundation/ethereumjs-tx": "5.0.2",
+        "@nomicfoundation/ethereumjs-util": "9.0.2",
         "abstract-level": "^1.0.3",
         "debug": "^4.3.3",
         "ethereum-cryptography": "0.1.3",
@@ -9384,36 +9368,36 @@
       }
     },
     "@nomicfoundation/ethereumjs-common": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-common/-/ethereumjs-common-4.0.1.tgz",
-      "integrity": "sha512-OBErlkfp54GpeiE06brBW/TTbtbuBJV5YI5Nz/aB2evTDo+KawyEzPjBlSr84z/8MFfj8wS2wxzQX1o32cev5g==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-common/-/ethereumjs-common-4.0.2.tgz",
+      "integrity": "sha512-I2WGP3HMGsOoycSdOTSqIaES0ughQTueOsddJ36aYVpI3SN8YSusgRFLwzDJwRFVIYDKx/iJz0sQ5kBHVgdDwg==",
       "requires": {
-        "@nomicfoundation/ethereumjs-util": "9.0.1",
+        "@nomicfoundation/ethereumjs-util": "9.0.2",
         "crc-32": "^1.2.0"
       }
     },
     "@nomicfoundation/ethereumjs-ethash": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-ethash/-/ethereumjs-ethash-3.0.1.tgz",
-      "integrity": "sha512-KDjGIB5igzWOp8Ik5I6QiRH5DH+XgILlplsHR7TEuWANZA759G6krQ6o8bvj+tRUz08YygMQu/sGd9mJ1DYT8w==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-ethash/-/ethereumjs-ethash-3.0.2.tgz",
+      "integrity": "sha512-8PfoOQCcIcO9Pylq0Buijuq/O73tmMVURK0OqdjhwqcGHYC2PwhbajDh7GZ55ekB0Px197ajK3PQhpKoiI/UPg==",
       "requires": {
-        "@nomicfoundation/ethereumjs-block": "5.0.1",
-        "@nomicfoundation/ethereumjs-rlp": "5.0.1",
-        "@nomicfoundation/ethereumjs-util": "9.0.1",
+        "@nomicfoundation/ethereumjs-block": "5.0.2",
+        "@nomicfoundation/ethereumjs-rlp": "5.0.2",
+        "@nomicfoundation/ethereumjs-util": "9.0.2",
         "abstract-level": "^1.0.3",
         "bigint-crypto-utils": "^3.0.23",
         "ethereum-cryptography": "0.1.3"
       }
     },
     "@nomicfoundation/ethereumjs-evm": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-evm/-/ethereumjs-evm-2.0.1.tgz",
-      "integrity": "sha512-oL8vJcnk0Bx/onl+TgQOQ1t/534GKFaEG17fZmwtPFeH8S5soiBYPCLUrvANOl4sCp9elYxIMzIiTtMtNNN8EQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-evm/-/ethereumjs-evm-2.0.2.tgz",
+      "integrity": "sha512-rBLcUaUfANJxyOx9HIdMX6uXGin6lANCulIm/pjMgRqfiCRMZie3WKYxTSd8ZE/d+qT+zTedBF4+VHTdTSePmQ==",
       "requires": {
         "@ethersproject/providers": "^5.7.1",
-        "@nomicfoundation/ethereumjs-common": "4.0.1",
-        "@nomicfoundation/ethereumjs-tx": "5.0.1",
-        "@nomicfoundation/ethereumjs-util": "9.0.1",
+        "@nomicfoundation/ethereumjs-common": "4.0.2",
+        "@nomicfoundation/ethereumjs-tx": "5.0.2",
+        "@nomicfoundation/ethereumjs-util": "9.0.2",
         "debug": "^4.3.3",
         "ethereum-cryptography": "0.1.3",
         "mcl-wasm": "^0.7.1",
@@ -9421,17 +9405,17 @@
       }
     },
     "@nomicfoundation/ethereumjs-rlp": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-rlp/-/ethereumjs-rlp-5.0.1.tgz",
-      "integrity": "sha512-xtxrMGa8kP4zF5ApBQBtjlSbN5E2HI8m8FYgVSYAnO6ssUoY5pVPGy2H8+xdf/bmMa22Ce8nWMH3aEW8CcqMeQ=="
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-rlp/-/ethereumjs-rlp-5.0.2.tgz",
+      "integrity": "sha512-QwmemBc+MMsHJ1P1QvPl8R8p2aPvvVcKBbvHnQOKBpBztEo0omN0eaob6FeZS/e3y9NSe+mfu3nNFBHszqkjTA=="
     },
     "@nomicfoundation/ethereumjs-statemanager": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-statemanager/-/ethereumjs-statemanager-2.0.1.tgz",
-      "integrity": "sha512-B5ApMOnlruVOR7gisBaYwFX+L/AP7i/2oAahatssjPIBVDF6wTX1K7Qpa39E/nzsH8iYuL3krkYeUFIdO3EMUQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-statemanager/-/ethereumjs-statemanager-2.0.2.tgz",
+      "integrity": "sha512-dlKy5dIXLuDubx8Z74sipciZnJTRSV/uHG48RSijhgm1V7eXYFC567xgKtsKiVZB1ViTP9iFL4B6Je0xD6X2OA==",
       "requires": {
-        "@nomicfoundation/ethereumjs-common": "4.0.1",
-        "@nomicfoundation/ethereumjs-rlp": "5.0.1",
+        "@nomicfoundation/ethereumjs-common": "4.0.2",
+        "@nomicfoundation/ethereumjs-rlp": "5.0.2",
         "debug": "^4.3.3",
         "ethereum-cryptography": "0.1.3",
         "ethers": "^5.7.1",
@@ -9439,27 +9423,27 @@
       }
     },
     "@nomicfoundation/ethereumjs-trie": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-trie/-/ethereumjs-trie-6.0.1.tgz",
-      "integrity": "sha512-A64It/IMpDVODzCgxDgAAla8jNjNtsoQZIzZUfIV5AY6Coi4nvn7+VReBn5itlxMiL2yaTlQr9TRWp3CSI6VoA==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-trie/-/ethereumjs-trie-6.0.2.tgz",
+      "integrity": "sha512-yw8vg9hBeLYk4YNg5MrSJ5H55TLOv2FSWUTROtDtTMMmDGROsAu+0tBjiNGTnKRi400M6cEzoFfa89Fc5k8NTQ==",
       "requires": {
-        "@nomicfoundation/ethereumjs-rlp": "5.0.1",
-        "@nomicfoundation/ethereumjs-util": "9.0.1",
+        "@nomicfoundation/ethereumjs-rlp": "5.0.2",
+        "@nomicfoundation/ethereumjs-util": "9.0.2",
         "@types/readable-stream": "^2.3.13",
         "ethereum-cryptography": "0.1.3",
         "readable-stream": "^3.6.0"
       }
     },
     "@nomicfoundation/ethereumjs-tx": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-tx/-/ethereumjs-tx-5.0.1.tgz",
-      "integrity": "sha512-0HwxUF2u2hrsIM1fsasjXvlbDOq1ZHFV2dd1yGq8CA+MEYhaxZr8OTScpVkkxqMwBcc5y83FyPl0J9MZn3kY0w==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-tx/-/ethereumjs-tx-5.0.2.tgz",
+      "integrity": "sha512-T+l4/MmTp7VhJeNloMkM+lPU3YMUaXdcXgTGCf8+ZFvV9NYZTRLFekRwlG6/JMmVfIfbrW+dRRJ9A6H5Q/Z64g==",
       "requires": {
         "@chainsafe/ssz": "^0.9.2",
         "@ethersproject/providers": "^5.7.2",
-        "@nomicfoundation/ethereumjs-common": "4.0.1",
-        "@nomicfoundation/ethereumjs-rlp": "5.0.1",
-        "@nomicfoundation/ethereumjs-util": "9.0.1",
+        "@nomicfoundation/ethereumjs-common": "4.0.2",
+        "@nomicfoundation/ethereumjs-rlp": "5.0.2",
+        "@nomicfoundation/ethereumjs-util": "9.0.2",
         "ethereum-cryptography": "0.1.3"
       },
       "dependencies": {
@@ -9493,12 +9477,12 @@
       }
     },
     "@nomicfoundation/ethereumjs-util": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-util/-/ethereumjs-util-9.0.1.tgz",
-      "integrity": "sha512-TwbhOWQ8QoSCFhV/DDfSmyfFIHjPjFBj957219+V3jTZYZ2rf9PmDtNOeZWAE3p3vlp8xb02XGpd0v6nTUPbsA==",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-util/-/ethereumjs-util-9.0.2.tgz",
+      "integrity": "sha512-4Wu9D3LykbSBWZo8nJCnzVIYGvGCuyiYLIJa9XXNVt1q1jUzHdB+sJvx95VGCpPkCT+IbLecW6yfzy3E1bQrwQ==",
       "requires": {
         "@chainsafe/ssz": "^0.10.0",
-        "@nomicfoundation/ethereumjs-rlp": "5.0.1",
+        "@nomicfoundation/ethereumjs-rlp": "5.0.2",
         "ethereum-cryptography": "0.1.3"
       },
       "dependencies": {
@@ -9522,19 +9506,19 @@
       }
     },
     "@nomicfoundation/ethereumjs-vm": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-vm/-/ethereumjs-vm-7.0.1.tgz",
-      "integrity": "sha512-rArhyn0jPsS/D+ApFsz3yVJMQ29+pVzNZ0VJgkzAZ+7FqXSRtThl1C1prhmlVr3YNUlfpZ69Ak+RUT4g7VoOuQ==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-vm/-/ethereumjs-vm-7.0.2.tgz",
+      "integrity": "sha512-Bj3KZT64j54Tcwr7Qm/0jkeZXJMfdcAtRBedou+Hx0dPOSIgqaIr0vvLwP65TpHbak2DmAq+KJbW2KNtIoFwvA==",
       "requires": {
-        "@nomicfoundation/ethereumjs-block": "5.0.1",
-        "@nomicfoundation/ethereumjs-blockchain": "7.0.1",
-        "@nomicfoundation/ethereumjs-common": "4.0.1",
-        "@nomicfoundation/ethereumjs-evm": "2.0.1",
-        "@nomicfoundation/ethereumjs-rlp": "5.0.1",
-        "@nomicfoundation/ethereumjs-statemanager": "2.0.1",
-        "@nomicfoundation/ethereumjs-trie": "6.0.1",
-        "@nomicfoundation/ethereumjs-tx": "5.0.1",
-        "@nomicfoundation/ethereumjs-util": "9.0.1",
+        "@nomicfoundation/ethereumjs-block": "5.0.2",
+        "@nomicfoundation/ethereumjs-blockchain": "7.0.2",
+        "@nomicfoundation/ethereumjs-common": "4.0.2",
+        "@nomicfoundation/ethereumjs-evm": "2.0.2",
+        "@nomicfoundation/ethereumjs-rlp": "5.0.2",
+        "@nomicfoundation/ethereumjs-statemanager": "2.0.2",
+        "@nomicfoundation/ethereumjs-trie": "6.0.2",
+        "@nomicfoundation/ethereumjs-tx": "5.0.2",
+        "@nomicfoundation/ethereumjs-util": "9.0.2",
         "debug": "^4.3.3",
         "ethereum-cryptography": "0.1.3",
         "mcl-wasm": "^0.7.1",
@@ -10124,14 +10108,6 @@
       "integrity": "sha512-LEyx4aLEC3x6T0UguF6YILf+ntvmOaWsVfENmIW0E9H09vKlLDGelMjjSm0jkDHALj8A8quZ/HapKNigzwge+Q==",
       "peer": true
     },
-    "abort-controller": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "requires": {
-        "event-target-shim": "^5.0.0"
-      }
-    },
     "abstract-level": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/abstract-level/-/abstract-level-1.0.3.tgz",
@@ -10414,9 +10390,9 @@
       "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="
     },
     "bigint-crypto-utils": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/bigint-crypto-utils/-/bigint-crypto-utils-3.2.2.tgz",
-      "integrity": "sha512-U1RbE3aX9ayCUVcIPHuPDPKcK3SFOXf93J1UK/iHlJuQB7bhagPIX06/CLpLEsDThJ7KA4Dhrnzynl+d2weTiw=="
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/bigint-crypto-utils/-/bigint-crypto-utils-3.3.0.tgz",
+      "integrity": "sha512-jOTSb+drvEDxEq6OuUybOAv/xxoh3cuYRUIPyu8sSHQNKM303UQ2R1DAo45o1AkcIXw6fzbaFI1+xGGdaXs2lg=="
     },
     "bignumber.js": {
       "version": "9.1.0",
@@ -10544,6 +10520,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
       "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "peer": true,
       "requires": {
         "function-bind": "^1.1.1",
         "get-intrinsic": "^1.0.2"
@@ -11795,11 +11772,6 @@
         "strip-hex-prefix": "1.0.0"
       }
     },
-    "event-target-shim": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
-    },
     "evp_bytestokey": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
@@ -11957,7 +11929,8 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "peer": true
     },
     "function.prototype.name": {
       "version": "1.1.5",
@@ -11997,6 +11970,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.0.tgz",
       "integrity": "sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==",
+      "peer": true,
       "requires": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
@@ -12162,27 +12136,26 @@
       }
     },
     "hardhat": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/hardhat/-/hardhat-2.14.0.tgz",
-      "integrity": "sha512-73jsInY4zZahMSVFurSK+5TNCJTXMv+vemvGia0Ac34Mm19fYp6vEPVGF3sucbumszsYxiTT2TbS8Ii2dsDSoQ==",
+      "version": "2.19.1",
+      "resolved": "https://registry.npmjs.org/hardhat/-/hardhat-2.19.1.tgz",
+      "integrity": "sha512-bsWa63g1GB78ZyMN08WLhFElLPA+J+pShuKD1BFO2+88g3l+BL3R07vj9deIi9dMbssxgE714Gof1dBEDGqnCw==",
       "requires": {
         "@ethersproject/abi": "^5.1.2",
         "@metamask/eth-sig-util": "^4.0.0",
-        "@nomicfoundation/ethereumjs-block": "5.0.1",
-        "@nomicfoundation/ethereumjs-blockchain": "7.0.1",
-        "@nomicfoundation/ethereumjs-common": "4.0.1",
-        "@nomicfoundation/ethereumjs-evm": "2.0.1",
-        "@nomicfoundation/ethereumjs-rlp": "5.0.1",
-        "@nomicfoundation/ethereumjs-statemanager": "2.0.1",
-        "@nomicfoundation/ethereumjs-trie": "6.0.1",
-        "@nomicfoundation/ethereumjs-tx": "5.0.1",
-        "@nomicfoundation/ethereumjs-util": "9.0.1",
-        "@nomicfoundation/ethereumjs-vm": "7.0.1",
+        "@nomicfoundation/ethereumjs-block": "5.0.2",
+        "@nomicfoundation/ethereumjs-blockchain": "7.0.2",
+        "@nomicfoundation/ethereumjs-common": "4.0.2",
+        "@nomicfoundation/ethereumjs-evm": "2.0.2",
+        "@nomicfoundation/ethereumjs-rlp": "5.0.2",
+        "@nomicfoundation/ethereumjs-statemanager": "2.0.2",
+        "@nomicfoundation/ethereumjs-trie": "6.0.2",
+        "@nomicfoundation/ethereumjs-tx": "5.0.2",
+        "@nomicfoundation/ethereumjs-util": "9.0.2",
+        "@nomicfoundation/ethereumjs-vm": "7.0.2",
         "@nomicfoundation/solidity-analyzer": "^0.1.0",
         "@sentry/node": "^5.18.1",
         "@types/bn.js": "^5.1.0",
         "@types/lru-cache": "^5.1.0",
-        "abort-controller": "^3.0.0",
         "adm-zip": "^0.4.16",
         "aggregate-error": "^3.0.0",
         "ansi-escapes": "^4.3.0",
@@ -12205,7 +12178,6 @@
         "mnemonist": "^0.38.0",
         "mocha": "^10.0.0",
         "p-map": "^4.0.0",
-        "qs": "^6.7.0",
         "raw-body": "^2.4.1",
         "resolve": "1.17.0",
         "semver": "^6.3.0",
@@ -12246,6 +12218,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "peer": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
@@ -12279,7 +12252,8 @@
     "has-symbols": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
+      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+      "peer": true
     },
     "has-tostringtag": {
       "version": "1.0.0",
@@ -12661,9 +12635,9 @@
       "peer": true
     },
     "js-sdsl": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.4.0.tgz",
-      "integrity": "sha512-FfVSdx6pJ41Oa+CF7RDaFmTnCaFhua+SNYQX74riGOpl96x+2jQCqEfQ2bnXu/5DPCqlRuiqyvTJM0Qjz26IVg=="
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.4.2.tgz",
+      "integrity": "sha512-dwXFwByc/ajSV6m5bcKAPwe4yDDF6D614pxmIi5odytzxRlwqF6nwoiCek80Ixc7Cvma5awClxrzFtxCQvcM8w=="
     },
     "js-sha3": {
       "version": "0.8.0",
@@ -13230,7 +13204,8 @@
     "object-inspect": {
       "version": "1.12.3",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
-      "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g=="
+      "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==",
+      "peer": true
     },
     "object-keys": {
       "version": "1.1.1",
@@ -13445,6 +13420,7 @@
       "version": "6.11.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
       "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
+      "peer": true,
       "requires": {
         "side-channel": "^1.0.4"
       }
@@ -13898,6 +13874,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
       "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "peer": true,
       "requires": {
         "call-bind": "^1.0.0",
         "get-intrinsic": "^1.0.2",

--- a/packages/local/registry/package.json
+++ b/packages/local/registry/package.json
@@ -7,6 +7,6 @@
     "@openzeppelin/hardhat-upgrades": "^1.21.0",
     "@tableland/evm": "^4.5.0",
     "erc721a-upgradeable": "^4.2.2",
-    "hardhat": "^2.14.0"
+    "hardhat": "^2.19.0"
   }
 }

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -53,11 +53,6 @@
     "dist/**/package.json",
     "src/**/*.ts"
   ],
-  "nx": {
-    "implicitDependencies": [
-      "!@tableland/local"
-    ]
-  },
   "scripts": {
     "prepublishOnly": "npm run build",
     "test": "npm run test:browser && npm run test:mocha",
@@ -81,16 +76,6 @@
     "database"
   ],
   "license": "MIT AND Apache-2.0",
-  "devDependencies": {
-    "@databases/escape-identifier": "^1.0.3",
-    "@databases/sql": "^3.2.0",
-    "@ethersproject/experimental": "^5.7.0",
-    "@playwright/test": "^1.30.0",
-    "d1-orm": "^0.9.0",
-    "drizzle-orm": "^0.29.0",
-    "openapi-typescript": "6.2.4",
-    "typedoc": "^0.25.0"
-  },
   "dependencies": {
     "@async-generators/from-emitter": "^0.3.0",
     "@tableland/evm": "^4.5.0",

--- a/packages/sdk/test/validator.test.ts
+++ b/packages/sdk/test/validator.test.ts
@@ -359,7 +359,7 @@ describe("validator", function () {
           unwrap: true,
         }),
         (err: any) => {
-          strictEqual(err.message, "Unexpected token { in JSON at position 30");
+          match(err.message, /at position 30/i);
           return true;
         }
       );


### PR DESCRIPTION
## Overview 
This upgrades the `@tableland/local` `hardhat` dependency version, and switches our invalid JSON error message detection to something that works for all LTS versions of node.js

## Details for each package

### CI
add node version 20 to the matrix

### SDK
Tests were updated to more lenient error message matching

### Local
`local`'s current version of Hardhat does not work with Node.js version 20.x.x  
If you try to use it you will receive the following error
```
unrecoverable error
Error: WARNING: You are using a version of Node.js that is not supported, and it may work incorrectly, or not work at all. See https://hardhat.org/nodejs-versions
```
Note, the newest version of `hardhat` works with all node.js LTS versions

### CLI
Only a small change needed here.  The read command is using string matching to detect invalid json as a result of incorrect use of the `--wrap` flag.  We have to update that string matching.
