### PR TITLE
feat: drop deprecated sdk methods

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tableland/sdk",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "description": "A database client and helpers for the Tableland network",
   "repository": {
     "type": "git",

--- a/packages/sdk/src/database.ts
+++ b/packages/sdk/src/database.ts
@@ -8,12 +8,10 @@ import { wrapResult, wrapExecResult } from "./registry/utils.js";
 import {
   type Config,
   type AutoWaitConfig,
-  type ChainName,
   type PollingController,
   type Signer,
   checkWait,
   extractBaseUrl,
-  getBaseUrl,
   normalize,
   readNameMapping,
   validateTableName,
@@ -22,7 +20,7 @@ import { Statement } from "./statement.js";
 import { execMutateMany, execCreateMany, errorWithCause } from "./lowlevel.js";
 
 /**
- * Database is the primary API for accessing the Tabeland network as a database.
+ * Database is the primary API for accessing the Tableland network as a database.
  * This class provides a small and simple API that will feel very familiar to
  * web2 database users. It includes the concept of prepared statements, SQL
  * parameter binding, execution and query modes, and more. It is actually similar
@@ -40,20 +38,6 @@ export class Database<D = unknown> {
    */
   constructor(config: Config & Partial<AutoWaitConfig> = {}) {
     this.config = config;
-  }
-
-  /**
-   * Create a Database that uses the default baseUrl for a given chain.
-   * @deprecated since 4.0.1, will be deleted in 5.0.0
-   * @param chainNameOrId The name or id of the chain to target.
-   * @returns A Database without a signer configured.
-   */
-  static readOnly(chainNameOrId: ChainName | number): Database {
-    console.warn(
-      "`Database.readOnly()` is a deprecated method, use `new Database()`"
-    );
-    const baseUrl = getBaseUrl(chainNameOrId);
-    return new Database({ baseUrl });
   }
 
   /**

--- a/packages/sdk/src/registry/index.ts
+++ b/packages/sdk/src/registry/index.ts
@@ -182,12 +182,4 @@ export class Registry {
   async mutate(params: MutateParams): Promise<ContractTransaction> {
     return await mutate(this.config, params);
   }
-
-  /**
-   * Runs a set of SQL statements for `caller` using `runnables`.
-   * @custom:deprecated Using this with a single statement is deprecated. Use `mutate` instead.
-   */
-  async runSQL(params: MutateParams): Promise<ContractTransaction> {
-    return await mutate(this.config, params);
-  }
 }

--- a/packages/sdk/test/database.test.ts
+++ b/packages/sdk/test/database.test.ts
@@ -35,12 +35,6 @@ describe("database", function () {
     strictEqual(db.config.baseUrl, "baseUrl");
   });
 
-  test("when initialized via .readOnly()", async function () {
-    const db = Database.readOnly("maticmum");
-    strictEqual(db.config.signer, undefined);
-    strictEqual(db.config.baseUrl, "https://testnets.tableland.network/api/v1");
-  });
-
   test("when initialized via .forSigner()", async function () {
     const db = await Database.forSigner(signer);
     strictEqual(db.config.signer, signer);

--- a/packages/sdk/test/registry.test.ts
+++ b/packages/sdk/test/registry.test.ts
@@ -256,40 +256,4 @@ describe("registry", function () {
       strictEqual(rec.transactionHash.length, 66);
     });
   });
-
-  describe(" *deprecated* runSQL()", function () {
-    // CREATE TABLE test_exec (id integer primary key, counter integer, info text)
-    let receipt: MultiEventTransactionReceipt;
-    this.beforeAll(async function () {
-      const tx = await reg.create({
-        chainId: 31337,
-        statement:
-          "create table test_runsql_31337 (id integer primary key, counter integer, info text)",
-      });
-      receipt = await getContractReceipt(tx);
-      notStrictEqual(receipt.tableIds[0], undefined);
-      strictEqual(receipt.chainId, 31337);
-    });
-    test("when insert statement is valid", async function () {
-      const tx = await reg.runSQL({
-        chainId: receipt.chainId,
-        tableId: receipt.tableIds[0],
-        statement: `INSERT INTO test_runsql_${receipt.chainId}_${receipt.tableIds[0]} (counter, info) VALUES (1, 'Tables');`,
-      });
-      const rec = await tx.wait();
-      strictEqual(typeof rec.transactionHash, "string");
-      strictEqual(rec.transactionHash.length, 66);
-    });
-
-    test("when insert statement is valid", async function () {
-      const tx = await reg.runSQL({
-        chainId: receipt.chainId,
-        tableId: receipt.tableIds[0],
-        statement: `UPDATE test_runsql_${receipt.chainId}_${receipt.tableIds[0]} SET counter=2`,
-      });
-      const rec = await tx.wait();
-      strictEqual(typeof rec.transactionHash, "string");
-      strictEqual(rec.transactionHash.length, 66);
-    });
-  });
 });


### PR DESCRIPTION
## Summary

Drop deprecated `Database.readOnly` and `Registry.runSQL` methods. Closes #105, #106.

## Details

See above.

## How it was tested

Removed tests that were previously using this logic.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
