### PR TITLE
(sdk) update `package-lock.json` with sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13074,7 +13074,7 @@
     },
     "packages/sdk": {
       "name": "@tableland/sdk",
-      "version": "5.1.1",
+      "version": "5.1.2",
       "license": "MIT AND Apache-2.0",
       "dependencies": {
         "@async-generators/from-emitter": "^0.3.0",


### PR DESCRIPTION
#108 was merged without running `npm install` hence the package-lock.json file has the wrong sdk version.  This updates package lock.