### PR TITLE
(local) better cleanup during start and shutdown

### DIFF
--- a/packages/local/src/main.ts
+++ b/packages/local/src/main.ts
@@ -277,7 +277,7 @@ class LocalTableland {
     // run this before starting in case the last instance of the validator
     // didn't get cleanup after this might be needed if a test runner force
     // quits the parent local-tableland process
-    this.validator.cleanup();
+    this.validator.cleanup(this.validatorDir);
     // shouldFork and chainId are optional, and the validator.start method
     // handles parsing them and filling in with defaults
     this.validator.start({
@@ -351,12 +351,13 @@ class LocalTableland {
     try {
       await this.shutdownValidator();
       await this.shutdownRegistry();
+
+      this.#_cleanup();
     } catch (err: any) {
+      this.#_cleanup();
       throw new Error(
         `unexpected error during shutdown: ${err.message as string}`
       );
-    } finally {
-      this.#_cleanup();
     }
   }
 
@@ -394,6 +395,7 @@ class LocalTableland {
 
       this.validator.process.on("close", () => resolve());
       this.validator.shutdown();
+      this.validator.cleanup();
     });
   }
 

--- a/packages/local/src/validators.ts
+++ b/packages/local/src/validators.ts
@@ -128,13 +128,27 @@ class ValidatorPkg {
   }
 
   // fully nuke the database and reset the config file
-  cleanup(): void {
+  cleanup(validatorDir?: string): void {
+    // we allow passing an optional directory to clean in case the user wants
+    // to cleanup before starting
+    if (typeof validatorDir !== "string") {
+      validatorDir = this.validatorDir;
+    }
+
+    // if there's no directory we can't cleanup
+    if (!validatorDir || validatorDir.trim() === "") return;
+
     shell.rm("-rf", resolve(this.validatorDir, "backups"));
 
     const dbFiles = [
       resolve(this.validatorDir, "database.db"),
+      resolve(this.validatorDir, "database.db-shm"),
+      resolve(this.validatorDir, "database.db-wal"),
       resolve(this.validatorDir, "metrics.db"),
+      resolve(this.validatorDir, "metrics.db-shm"),
+      resolve(this.validatorDir, "metrics.db-wal"),
     ];
+
     for (const filepath of dbFiles) {
       shell.rm("-f", filepath);
     }


### PR DESCRIPTION
## Overview

As seen here, https://gist.github.com/dtbuchholz/ff5a8c261ff282bb72476bc1ad02f328#file-e2e-test-ts, the hardhat snapshotting was not working because the database backup was not being reset when the Validator was reset.

## Details

This PR fixes the reset procedure to allow chain snapshotting, and also include better cleanup logic for database backup files.