### PR TITLE
update package lock before publish

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14595,16 +14595,6 @@
         "yargs": "^17.6.2"
       },
       "dependencies": {
-        "@tableland/sdk": {
-          "version": "https://registry.npmjs.org/@tableland/sdk/-/sdk-5.2.0.tgz",
-          "integrity": "sha512-tqu6ByCm4oz1Ml/bZBeBYPeEsxW6pqbNY+VGV+PQ+UFpMU+cf4T202hki4s69F2nnE3HpgaPrXPKYD8Z55pU+Q==",
-          "requires": {
-            "@async-generators/from-emitter": "^0.3.0",
-            "@tableland/evm": "^4.5.0",
-            "@tableland/sqlparser": "^1.3.0",
-            "ethers": "^5.7.2"
-          }
-        },
         "ansi-escapes": {
           "version": "4.3.2",
           "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",


### PR DESCRIPTION
`npm install` wasn't run before #129 was merged, so package-lock.json needed one change before publishing.