### PR TITLE
replace mumbai with amoy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2158,9 +2158,9 @@
       "integrity": "sha512-5DddKKbxa3q1DcUBcf+D9bF0xYjoqWYRs8t941vZWDMRQjuHNPW7JjRA0W8zH+LDeKYqWmyJFsm1se8RxTcJPA=="
     },
     "node_modules/@tableland/validator": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@tableland/validator/-/validator-1.8.1.tgz",
-      "integrity": "sha512-8A2oNjNlvJnydSZWFFcFwGrLv/cFu6r2KPY5UgMXdMQxciKQzJ7XmGJODflKSpr2jwMLQV+oqSzlTmr08pQdow=="
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@tableland/validator/-/validator-1.10.2.tgz",
+      "integrity": "sha512-msGDUcJPu/ecD/Wvcggivj6KMk9KIqpE4qzw3O5uSkGEA2Sy46/WoRzw8BhvWPpv7r3tHPAC8o7qrrR8P2oG0g=="
     },
     "node_modules/@tootallnate/once": {
       "version": "2.0.0",
@@ -12772,12 +12772,12 @@
     },
     "packages/cli": {
       "name": "@tableland/cli",
-      "version": "6.0.0",
+      "version": "7.0.0",
       "license": "MIT AND Apache-2.0",
       "dependencies": {
         "@ensdomains/ensjs": "3.0.0-alpha.64",
         "@tableland/node-helpers": "^0.0.2",
-        "@tableland/sdk": "^6.0.0",
+        "@tableland/sdk": "^7.0.0",
         "@tableland/sqlparser": "^1.3.0",
         "cli-select-2": "^2.0.0",
         "cosmiconfig": "^9.0.0",
@@ -13032,12 +13032,12 @@
     },
     "packages/local": {
       "name": "@tableland/local",
-      "version": "2.4.1",
+      "version": "3.0.0",
       "hasInstallScript": true,
       "license": "MIT AND Apache-2.0",
       "dependencies": {
-        "@tableland/sdk": "^5.1.0",
-        "@tableland/validator": "^1.8.1",
+        "@tableland/sdk": "^7.0.0",
+        "@tableland/validator": "^1.10.2",
         "cross-spawn": "^7.0.3",
         "dotenv": "^16.4.1",
         "enquirer": "^2.3.6",
@@ -13050,17 +13050,6 @@
       },
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "packages/local/node_modules/@tableland/sdk": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@tableland/sdk/-/sdk-5.2.0.tgz",
-      "integrity": "sha512-tqu6ByCm4oz1Ml/bZBeBYPeEsxW6pqbNY+VGV+PQ+UFpMU+cf4T202hki4s69F2nnE3HpgaPrXPKYD8Z55pU+Q==",
-      "dependencies": {
-        "@async-generators/from-emitter": "^0.3.0",
-        "@tableland/evm": "^4.5.0",
-        "@tableland/sqlparser": "^1.3.0",
-        "ethers": "^5.7.2"
       }
     },
     "packages/local/node_modules/cliui": {
@@ -13135,7 +13124,7 @@
     },
     "packages/sdk": {
       "name": "@tableland/sdk",
-      "version": "6.0.0",
+      "version": "7.0.0",
       "license": "MIT AND Apache-2.0",
       "dependencies": {
         "@async-generators/from-emitter": "^0.3.0",
@@ -14580,7 +14569,7 @@
       "requires": {
         "@ensdomains/ensjs": "3.0.0-alpha.64",
         "@tableland/node-helpers": "^0.0.2",
-        "@tableland/sdk": "^6.0.0",
+        "@tableland/sdk": "^7.0.0",
         "@tableland/sqlparser": "^1.3.0",
         "cli-select-2": "^2.0.0",
         "cosmiconfig": "^9.0.0",
@@ -14734,8 +14723,8 @@
     "@tableland/local": {
       "version": "file:packages/local",
       "requires": {
-        "@tableland/sdk": "^5.1.0",
-        "@tableland/validator": "^1.8.1",
+        "@tableland/sdk": "^7.0.0",
+        "@tableland/validator": "^1.10.2",
         "cross-spawn": "^7.0.3",
         "dotenv": "^16.4.1",
         "enquirer": "^2.3.6",
@@ -14745,8 +14734,7 @@
       },
       "dependencies": {
         "@tableland/sdk": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/@tableland/sdk/-/sdk-5.2.0.tgz",
+          "version": "https://registry.npmjs.org/@tableland/sdk/-/sdk-5.2.0.tgz",
           "integrity": "sha512-tqu6ByCm4oz1Ml/bZBeBYPeEsxW6pqbNY+VGV+PQ+UFpMU+cf4T202hki4s69F2nnE3HpgaPrXPKYD8Z55pU+Q==",
           "requires": {
             "@async-generators/from-emitter": "^0.3.0",
@@ -14831,9 +14819,9 @@
       "integrity": "sha512-5DddKKbxa3q1DcUBcf+D9bF0xYjoqWYRs8t941vZWDMRQjuHNPW7JjRA0W8zH+LDeKYqWmyJFsm1se8RxTcJPA=="
     },
     "@tableland/validator": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@tableland/validator/-/validator-1.8.1.tgz",
-      "integrity": "sha512-8A2oNjNlvJnydSZWFFcFwGrLv/cFu6r2KPY5UgMXdMQxciKQzJ7XmGJODflKSpr2jwMLQV+oqSzlTmr08pQdow=="
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@tableland/validator/-/validator-1.10.2.tgz",
+      "integrity": "sha512-msGDUcJPu/ecD/Wvcggivj6KMk9KIqpE4qzw3O5uSkGEA2Sy46/WoRzw8BhvWPpv7r3tHPAC8o7qrrR8P2oG0g=="
     },
     "@tootallnate/once": {
       "version": "2.0.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tableland/cli",
-  "version": "6.0.0",
+  "version": "7.0.0",
   "description": "Tableland command line tools",
   "repository": {
     "type": "git",
@@ -50,7 +50,7 @@
   "dependencies": {
     "@ensdomains/ensjs": "3.0.0-alpha.64",
     "@tableland/node-helpers": "^0.0.2",
-    "@tableland/sdk": "^6.0.0",
+    "@tableland/sdk": "^7.0.0",
     "@tableland/sqlparser": "^1.3.0",
     "cli-select-2": "^2.0.0",
     "cosmiconfig": "^9.0.0",

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -15,7 +15,7 @@ export interface Options extends GlobalOptions {
 }
 
 const defaults = {
-  chain: "maticmum",
+  chain: "polygon-amoy",
   rpcRelay: false,
 };
 

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -39,8 +39,9 @@ export function getLink(chain: helpers.ChainName, hash: string): string {
     }
     return `https://etherscan.io/tx/${hash}`;
   } else if (chain.includes("polygon")) {
-    if (chain.includes("mumbai")) {
-      return `https://mumbai.polygonscan.com/tx/${hash}`;
+    if (chain.includes("amoy")) {
+      // TODO: polyscan says they will support amoy "soon", when that happens replace oklink with polyscan
+      return `https://www.oklink.com/amoy/tx/${hash}`;
     }
     return `https://polygonscan.com/tx/${hash}`;
   } else if (chain.includes("optimism")) {

--- a/packages/cli/test/list.test.ts
+++ b/packages/cli/test/list.test.ts
@@ -22,7 +22,7 @@ describe("commands/list", function () {
 
   test("throws without privateKey or address", async function () {
     const consoleError = spy(logger, "error");
-    await yargs(["list", "--chain", "maticmum", ...defaultArgs])
+    await yargs(["list", "--chain", "polygon-amoy", ...defaultArgs])
       .command(mod)
       .parse();
 

--- a/packages/local/package.json
+++ b/packages/local/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tableland/local",
-  "version": "2.4.1",
+  "version": "3.0.0",
   "description": "Tooling to start a sandboxed Tableland network.",
   "repository": {
     "type": "git",
@@ -65,8 +65,8 @@
     "up:dev": "node dist/esm/up.js --validator ../go-tableland --registry ../evm-tableland"
   },
   "dependencies": {
-    "@tableland/sdk": "^5.1.0",
-    "@tableland/validator": "^1.8.1",
+    "@tableland/sdk": "^7.0.0",
+    "@tableland/validator": "^1.10.2",
     "cross-spawn": "^7.0.3",
     "dotenv": "^16.4.1",
     "enquirer": "^2.3.6",

--- a/packages/local/registry/hardhat.config.ts
+++ b/packages/local/registry/hardhat.config.ts
@@ -41,7 +41,7 @@ if (process.env.FORK_CHAIN_ID && process.env.FORK_URL) {
   const chainInfo = helpers.getChainInfo(chainId);
   const chainName = chainInfo.chainName;
 
-  if (chainName === "matic") {
+  if (chainName === "polygon") {
     networks.hardhat.chains = {
       137: {
         hardforkHistory: {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tableland/sdk",
-  "version": "6.0.0",
+  "version": "7.0.0",
   "description": "A database client and helpers for the Tableland network",
   "repository": {
     "type": "git",
@@ -82,7 +82,7 @@
   "license": "MIT AND Apache-2.0",
   "dependencies": {
     "@async-generators/from-emitter": "^0.3.0",
-    "@tableland/evm": "^5.0.0",
+    "@tableland/evm": "^6.0.0",
     "@tableland/sqlparser": "^1.3.0",
     "ethers": "^5.7.2"
   }

--- a/packages/sdk/test/chains.test.ts
+++ b/packages/sdk/test/chains.test.ts
@@ -22,8 +22,8 @@ describe("chains", function () {
       const testnets = "https://testnets.tableland.network/api/v1";
       const mainnet = "https://tableland.network/api/v1";
       strictEqual(getBaseUrl("localhost"), localhost);
-      strictEqual(getBaseUrl("maticmum"), testnets);
-      strictEqual(getBaseUrl("matic"), mainnet);
+      strictEqual(getBaseUrl("polygon-amoy"), testnets);
+      strictEqual(getBaseUrl("polygon"), mainnet);
       strictEqual(getBaseUrl("optimism"), mainnet);
       strictEqual(getBaseUrl("mainnet"), mainnet);
     });
@@ -32,15 +32,15 @@ describe("chains", function () {
   describe("getContractAddress()", function () {
     test("where we check the known default localhost contract address", async function () {
       const localhost = "0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512";
-      const matic = "0x5c4e6A9e5C1e1BF445A062006faF19EA6c49aFeA";
+      const polygon = "0x5c4e6A9e5C1e1BF445A062006faF19EA6c49aFeA";
       // Note we're checking local-tableland here, rather than localhost
       strictEqual(
         getContractAddress("local-tableland").toLowerCase(),
         localhost.toLowerCase()
       );
       strictEqual(
-        getContractAddress("matic").toLowerCase(),
-        matic.toLowerCase()
+        getContractAddress("polygon").toLowerCase(),
+        polygon.toLowerCase()
       );
     });
   });
@@ -50,7 +50,7 @@ describe("chains", function () {
       const testnets: ChainName[] = [
         "sepolia",
         "arbitrum-sepolia",
-        "maticmum",
+        "polygon-amoy",
         "optimism-sepolia",
         "local-tableland",
         "localhost",
@@ -58,7 +58,7 @@ describe("chains", function () {
       const mainnets: ChainName[] = [
         "mainnet",
         "arbitrum",
-        "matic",
+        "polygon",
         "optimism",
       ];
       for (const net of testnets) {
@@ -74,7 +74,7 @@ describe("chains", function () {
     test("where we make sure supportedChains is a valid object", function () {
       strictEqual(Object.keys(supportedChains).length >= 12, true);
       strictEqual(Object.keys(supportedChains).includes("mainnet"), true);
-      strictEqual(Object.keys(supportedChains).includes("maticmum"), true);
+      strictEqual(Object.keys(supportedChains).includes("polygon-amoy"), true);
       strictEqual(Object.keys(supportedChains).includes("localhost"), true);
     });
   });
@@ -84,14 +84,14 @@ describe("chains", function () {
       // Mainnets
       strictEqual(getChainId("mainnet"), 1);
       strictEqual(getChainId("homestead"), 1);
-      strictEqual(getChainId("matic"), 137);
+      strictEqual(getChainId("polygon"), 137);
       strictEqual(getChainId("optimism"), 10);
       strictEqual(getChainId("arbitrum"), 42161);
       strictEqual(getChainId("arbitrum-nova"), 42170);
       strictEqual(getChainId("filecoin"), 314);
       // Testnets
       strictEqual(getChainId("sepolia"), 11155111);
-      strictEqual(getChainId("maticmum"), 80001);
+      strictEqual(getChainId("polygon-amoy"), 80002);
       strictEqual(getChainId("optimism-sepolia"), 11155420);
       strictEqual(getChainId("arbitrum-sepolia"), 421614);
       strictEqual(getChainId("filecoin-calibration"), 314159);
@@ -112,9 +112,9 @@ describe("chains", function () {
       const localhost = getChainInfo("localhost");
       strictEqual(localhost.baseUrl, localhostUrl);
       strictEqual(localhost.chainId, 31337);
-      const maticmum = getChainInfo("maticmum");
-      strictEqual(maticmum.baseUrl, testnetsUrl);
-      strictEqual(maticmum.chainId, 80001);
+      const polygonAmoy = getChainInfo("polygon-amoy");
+      strictEqual(polygonAmoy.baseUrl, testnetsUrl);
+      strictEqual(polygonAmoy.chainId, 80002);
     });
 
     test("where it fails when invalid chain is passed", function () {
@@ -146,22 +146,22 @@ describe("chains", function () {
     test("where we get polling controller with chain ids", async function () {
       const homesteadController = getChainPollingController(1); // mainnet
       const filecoinController = getChainPollingController(314); // filecoin
-      const maticmumController = getChainPollingController(80001); // polygon mumbai
+      const polygonAmoyController = getChainPollingController(80002); // polygon mumbai
       const filecoinTestnetController = getChainPollingController(314159); // filecoin testnet
       const localController = getChainPollingController(31337); // local
       strictEqual(homesteadController.interval, 1500); // most should use the same 1500ms interval
       strictEqual(homesteadController.timeout, 40000); // but different timeouts
       strictEqual(filecoinController.interval, 5000); // filecoin has longer intervals
       strictEqual(filecoinController.timeout, 210000);
-      strictEqual(maticmumController.interval, 1500);
-      strictEqual(maticmumController.timeout, 15000);
+      strictEqual(polygonAmoyController.interval, 1500);
+      strictEqual(polygonAmoyController.timeout, 15000);
       strictEqual(filecoinTestnetController.interval, 5000);
       strictEqual(filecoinTestnetController.timeout, 210000);
       strictEqual(localController.interval, 1500);
       strictEqual(localController.timeout, 5000);
       homesteadController.cancel();
       filecoinController.cancel();
-      maticmumController.cancel();
+      polygonAmoyController.cancel();
       filecoinTestnetController.cancel();
       localController.cancel();
     });
@@ -206,22 +206,22 @@ describe("chains", function () {
     test("where we get polling controller with chain ids", async function () {
       const homesteadController = getChainPollingController(1); // mainnet
       const filecoinController = getChainPollingController(314); // filecoin
-      const maticmumController = getChainPollingController(80001); // polygon mumbai
+      const polygonAmoyController = getChainPollingController(80002); // polygon mumbai
       const filecoinTestnetController = getChainPollingController(314159); // filecoin testnet
       const localController = getChainPollingController(31337); // local
       strictEqual(homesteadController.interval, 1500); // most should use the same 1500ms interval
       strictEqual(homesteadController.timeout, 40000); // but different timeouts
       strictEqual(filecoinController.interval, 5000); // filecoin has longer intervals
       strictEqual(filecoinController.timeout, 210000);
-      strictEqual(maticmumController.interval, 1500);
-      strictEqual(maticmumController.timeout, 15000);
+      strictEqual(polygonAmoyController.interval, 1500);
+      strictEqual(polygonAmoyController.timeout, 15000);
       strictEqual(filecoinTestnetController.interval, 5000);
       strictEqual(filecoinTestnetController.timeout, 210000);
       strictEqual(localController.interval, 1500);
       strictEqual(localController.timeout, 5000);
       homesteadController.cancel();
       filecoinController.cancel();
-      maticmumController.cancel();
+      polygonAmoyController.cancel();
       filecoinTestnetController.cancel();
       localController.cancel();
     });

--- a/packages/sdk/test/validator.test.ts
+++ b/packages/sdk/test/validator.test.ts
@@ -43,8 +43,8 @@ describe("validator", function () {
   });
 
   test("when initialized via .forChain()", async function () {
-    const reg = Validator.forChain("maticmum");
-    strictEqual(reg.config.baseUrl, getBaseUrl("maticmum"));
+    const reg = Validator.forChain("polygon-amoy");
+    strictEqual(reg.config.baseUrl, getBaseUrl("polygon-amoy"));
   });
 
   this.beforeAll(async function () {


### PR DESCRIPTION
Stubbed out PR to replace mumbai with amoy. Related to https://github.com/tablelandnetwork/evm-tableland/pull/489

Note: the Polygon network names are sometimes referred to as "matic" and "maticmum", and sometimes referred to as "polygon" and "polygon-mumbai".  This change switches to the convention of using "polygon" and "polygon-amoy".  I did this since Polygon seems to be moving to use those terms. I'm open to alternatives, but we will need a docs update no matter what.