### PR TITLE
(local) fix deviation from prettier rule in config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3846,6 +3846,7 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/@tableland/evm/-/evm-4.5.0.tgz",
       "integrity": "sha512-dvkLrxNXJXUvroF1GqqlAX2DGB+fN8UYeKMWBYz9iEYK+GVbaFyJfE34MfUbT7TXYaIXa4dqMfhI0rk+3zcpuw==",
+      "dev": true,
       "dependencies": {
         "@openzeppelin/contracts": "4.8.3"
       },
@@ -22039,6 +22040,7 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/@tableland/evm/-/evm-4.5.0.tgz",
       "integrity": "sha512-dvkLrxNXJXUvroF1GqqlAX2DGB+fN8UYeKMWBYz9iEYK+GVbaFyJfE34MfUbT7TXYaIXa4dqMfhI0rk+3zcpuw==",
+      "dev": true,
       "requires": {
         "@openzeppelin/contracts": "4.8.3"
       }
@@ -22056,16 +22058,6 @@
         "yargs": "^17.5.1"
       },
       "dependencies": {
-        "@tableland/sdk": {
-          "version": "https://registry.npmjs.org/@tableland/sdk/-/sdk-5.2.0.tgz",
-          "integrity": "sha512-tqu6ByCm4oz1Ml/bZBeBYPeEsxW6pqbNY+VGV+PQ+UFpMU+cf4T202hki4s69F2nnE3HpgaPrXPKYD8Z55pU+Q==",
-          "requires": {
-            "@async-generators/from-emitter": "^0.3.0",
-            "@tableland/evm": "^4.5.0",
-            "@tableland/sqlparser": "^1.3.0",
-            "ethers": "^5.7.2"
-          }
-        },
         "cliui": {
           "version": "8.0.1",
           "requires": {

--- a/packages/local/src/validators.ts
+++ b/packages/local/src/validators.ts
@@ -16,6 +16,17 @@ const spawnSync = spawn.sync;
 // store the Validator config file in memory, so we can restore it during cleanup
 let ORIGINAL_VALIDATOR_CONFIG: string | undefined;
 
+function _getEol(fileStr: string): string {
+  if (fileStr.slice(-2) === "\r\n") {
+    return "\r\n";
+  }
+  if (fileStr.slice(-1) === "\n") {
+    return "\n";
+  }
+
+  return "";
+}
+
 interface StartConfig {
   chainId?: number;
   registryAddress?: string;
@@ -98,7 +109,10 @@ class ValidatorPkg {
     if (typeof config.chainId === "number") {
       validatorConfig.Chains[0].ChainID = config.chainId;
     }
-    writeFileSync(configFilePath, JSON.stringify(validatorConfig, null, 2));
+    writeFileSync(
+      configFilePath,
+      JSON.stringify(validatorConfig, null, 2) + _getEol(configFileStr)
+    );
 
     // start the validator
     this.process = spawn(binPath, ["--dir", validatorUri], {
@@ -214,7 +228,10 @@ class ValidatorDev {
 
     validatorConfig.Chains[0].Registry.ContractAddress = config.registryAddress;
 
-    writeFileSync(configFilePath, JSON.stringify(validatorConfig, null, 2));
+    writeFileSync(
+      configFilePath,
+      JSON.stringify(validatorConfig, null, 2) + _getEol(configFileStr)
+    );
 
     // start the validator
     this.process = spawn("make", ["local-up"], {

--- a/packages/node-helpers/test/setup.ts
+++ b/packages/node-helpers/test/setup.ts
@@ -36,7 +36,7 @@ const lt = new LocalTableland({
 });
 
 before(async function () {
-  this.timeout(TEST_TIMEOUT_FACTOR * 30000);
+  this.timeout(TEST_TIMEOUT_FACTOR * 40000);
   await lt.start();
 });
 


### PR DESCRIPTION
I've been noticing that `local` extends the validator config and does so without including a new line character at the end of the file.  This means that if you accidentally commit while the validator is running you potentially commit a violation of this repo's prettier.

This PR includes the EOL character in the generated config file.