### PR TITLE
(local) add more extraneous log filters

### DIFF
--- a/packages/local/src/util.ts
+++ b/packages/local/src/util.ts
@@ -229,18 +229,20 @@ export const getConfigFile = async function (): Promise<
 const isExtraneousLog = function (log: string): boolean {
   log = log.toLowerCase();
 
+  if (log.match(/dropping new height/i) != null) return true;
+  if (log.match(/eth_blockNumber/i) != null) return true;
+  if (log.match(/eth_feeHistory/i) != null) return true;
   if (log.match(/eth_getLogs/i) != null) return true;
-  if (log.match(/Mined empty block/i) != null) return true;
   if (log.match(/eth_getBlockByNumber/i) != null) return true;
   if (log.match(/eth_getBalance/i) != null) return true;
-  if (log.match(/processing height/i) != null) return true;
-  if (log.match(/new last processed height/i) != null) return true;
-  if (log.match(/eth_unsubscribe/i) != null) return true;
   if (log.match(/eth_subscribe/i) != null) return true;
+  if (log.match(/eth_unsubscribe/i) != null) return true;
+  if (log.match(/Mined empty block/i) != null) return true;
   if (log.match(/new blocks subscription is quiet, rebuilding/i) != null)
     return true;
+  if (log.match(/new last processed height/i) != null) return true;
+  if (log.match(/processing height/i) != null) return true;
   if (log.match(/received new chain header/i) != null) return true;
-  if (log.match(/dropping new height/i) != null) return true;
 
   return false;
 };


### PR DESCRIPTION
With recent upgrades the messages hardhat logs have changed a little bit.  This PR filters out a few new log messages that come in at a regular basis regardless of if there is anything happening on the network.
This also alphabetizes the log message filters.