### PR TITLE
(local) ensure shutdown cannot be run repeatedly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18640,7 +18640,7 @@
     },
     "packages/local": {
       "name": "@tableland/local",
-      "version": "3.0.1",
+      "version": "3.0.2",
       "hasInstallScript": true,
       "license": "MIT AND Apache-2.0",
       "dependencies": {

--- a/packages/local/package.json
+++ b/packages/local/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tableland/local",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Tooling to start a sandboxed Tableland network.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
I've been getting an error recently where the SIGINT event is being received twice by local tableland.

After some debugging, it looks like when Ctrl+C is pressed, the shell sends a SIGINT signal to the foreground process/process-group. If the foreground process is Node, it's only sent to the Node process. But when it's an npm process with a child Node process attached, the SIGINT is sent to both npm and Node processes.
The Node process receives the signal a second time is because the npm process listens to signals and relays them to the child Node process.

This change ensures that an instance of LT will not try to shutdown twice in parallel if the signal is received twice.