### PR TITLE
upgrade sqlparser with alias fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3883,9 +3883,9 @@
       "link": true
     },
     "node_modules/@tableland/sqlparser": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@tableland/sqlparser/-/sqlparser-1.3.0.tgz",
-      "integrity": "sha512-5DddKKbxa3q1DcUBcf+D9bF0xYjoqWYRs8t941vZWDMRQjuHNPW7JjRA0W8zH+LDeKYqWmyJFsm1se8RxTcJPA=="
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@tableland/sqlparser/-/sqlparser-1.4.1.tgz",
+      "integrity": "sha512-j8VTruuNm6WA+EuUKTHK4w1zinmsf0P0w9vTD8x8EzrUaXpIQx8/+51Kw2CqgyOhwaKbXrMUTycJbeWfXW5U0A=="
     },
     "node_modules/@tableland/studio-api": {
       "version": "0.0.3",
@@ -18322,12 +18322,12 @@
     },
     "packages/cli": {
       "name": "@tableland/cli",
-      "version": "7.3.0",
+      "version": "7.3.1",
       "license": "MIT AND Apache-2.0",
       "dependencies": {
         "@tableland/node-helpers": "^1.0.0",
         "@tableland/sdk": "^7.2.0",
-        "@tableland/sqlparser": "^1.3.0",
+        "@tableland/sqlparser": "^1.4.1",
         "@tableland/studio-cli": "^0.3.0",
         "cli-select-2": "^2.0.0",
         "cosmiconfig": "^9.0.0",
@@ -18818,12 +18818,12 @@
     },
     "packages/sdk": {
       "name": "@tableland/sdk",
-      "version": "7.2.0",
+      "version": "7.2.1",
       "license": "MIT AND Apache-2.0",
       "dependencies": {
         "@async-generators/from-emitter": "^0.3.0",
         "@tableland/evm": "^6.3.0",
-        "@tableland/sqlparser": "^1.3.0",
+        "@tableland/sqlparser": "^1.4.1",
         "ethers": "^6.12.1"
       }
     },
@@ -21385,7 +21385,7 @@
       "requires": {
         "@tableland/node-helpers": "^1.0.0",
         "@tableland/sdk": "^7.2.0",
-        "@tableland/sqlparser": "^1.3.0",
+        "@tableland/sqlparser": "^1.4.1",
         "@tableland/studio-cli": "^0.3.0",
         "cli-select-2": "^2.0.0",
         "cosmiconfig": "^9.0.0",
@@ -21729,7 +21729,7 @@
       "requires": {
         "@async-generators/from-emitter": "^0.3.0",
         "@tableland/evm": "^6.3.0",
-        "@tableland/sqlparser": "^1.3.0",
+        "@tableland/sqlparser": "^1.4.1",
         "ethers": "^6.12.1"
       },
       "dependencies": {
@@ -21781,9 +21781,9 @@
       }
     },
     "@tableland/sqlparser": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@tableland/sqlparser/-/sqlparser-1.3.0.tgz",
-      "integrity": "sha512-5DddKKbxa3q1DcUBcf+D9bF0xYjoqWYRs8t941vZWDMRQjuHNPW7JjRA0W8zH+LDeKYqWmyJFsm1se8RxTcJPA=="
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@tableland/sqlparser/-/sqlparser-1.4.1.tgz",
+      "integrity": "sha512-j8VTruuNm6WA+EuUKTHK4w1zinmsf0P0w9vTD8x8EzrUaXpIQx8/+51Kw2CqgyOhwaKbXrMUTycJbeWfXW5U0A=="
     },
     "@tableland/studio-api": {
       "version": "0.0.3",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tableland/cli",
-  "version": "7.3.0",
+  "version": "7.3.1",
   "description": "Tableland command line tools",
   "repository": {
     "type": "git",
@@ -50,7 +50,7 @@
   "dependencies": {
     "@tableland/node-helpers": "^1.0.0",
     "@tableland/sdk": "^7.2.0",
-    "@tableland/sqlparser": "^1.3.0",
+    "@tableland/sqlparser": "^1.4.1",
     "@tableland/studio-cli": "^0.3.0",
     "cli-select-2": "^2.0.0",
     "cosmiconfig": "^9.0.0",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tableland/sdk",
-  "version": "7.2.0",
+  "version": "7.2.1",
   "description": "A database client and helpers for the Tableland network",
   "repository": {
     "type": "git",
@@ -83,7 +83,7 @@
   "dependencies": {
     "@async-generators/from-emitter": "^0.3.0",
     "@tableland/evm": "^6.3.0",
-    "@tableland/sqlparser": "^1.3.0",
+    "@tableland/sqlparser": "^1.4.1",
     "ethers": "^6.12.1"
   }
 }


### PR DESCRIPTION
In order to enable the Studio console to work with tables that do not have a prefix, we had to update the sqlparser to allow table names that start with `_`.  This change includes the updated version of the wasm sql parser